### PR TITLE
Enable a configurable log-in mechanism

### DIFF
--- a/cookbook.yml
+++ b/cookbook.yml
@@ -10,5 +10,6 @@ database:
   password: ${DB_PASSWORD:-sa}
   url: ${DB_JDBC_URL:-jdbc:h2:./db}
 autoRunMigration: ${AUTO_RUN_MIGRATION:-no}
-oauthConfig:
+auth:
+  type: username
   clientId: ${COOKBOOK_CLIENT_ID}

--- a/server/src/main/kotlin/com/github/ptrteixeira/cookbook/CookbookConfiguration.kt
+++ b/server/src/main/kotlin/com/github/ptrteixeira/cookbook/CookbookConfiguration.kt
@@ -1,12 +1,12 @@
 package com.github.ptrteixeira.cookbook
 
-import com.github.ptrteixeira.cookbook.config.OauthConfiguration
+import com.github.ptrteixeira.cookbook.config.AuthConfiguration
 import io.dropwizard.Configuration
 import io.dropwizard.db.DataSourceFactory
 
 class CookbookConfiguration(
     val database: DataSourceFactory = DataSourceFactory(),
-    val oauthConfig: OauthConfiguration,
+    val auth: AuthConfiguration,
     val autoRunMigration: Boolean = false,
     val baseUrl: String = "http://localhost:8080"
 ) : Configuration()

--- a/server/src/main/kotlin/com/github/ptrteixeira/cookbook/auth/AuthComponent.kt
+++ b/server/src/main/kotlin/com/github/ptrteixeira/cookbook/auth/AuthComponent.kt
@@ -11,7 +11,11 @@ interface AuthComponent {
     @Named(TOKEN_AUTH)
     fun tokenAuth(): Authenticator<String, User>
 
+    @Named(USERNAME_AUTH)
+    fun usernameAuth(): Authenticator<String, User>
+
     companion object {
         const val TOKEN_AUTH = "com.github.ptrteixeira.cookbook.auth.tokenAuth"
+        const val USERNAME_AUTH = "com.github.ptrteixeira.cookbook.auth.usernameAuth"
     }
 }

--- a/server/src/main/kotlin/com/github/ptrteixeira/cookbook/auth/AuthModule.kt
+++ b/server/src/main/kotlin/com/github/ptrteixeira/cookbook/auth/AuthModule.kt
@@ -1,6 +1,6 @@
 package com.github.ptrteixeira.cookbook.auth
 
-import com.github.ptrteixeira.cookbook.config.OauthConfiguration
+import com.github.ptrteixeira.cookbook.config.AuthConfiguration
 import com.github.ptrteixeira.cookbook.core.User
 import com.google.api.client.googleapis.auth.oauth2.GoogleIdTokenVerifier
 import com.google.api.client.http.HttpTransport
@@ -17,13 +17,19 @@ internal class AuthModule {
     fun httpTransport(): HttpTransport = NetHttpTransport()
 
     @Provides
-    fun googleTokenVerifier(oauthConfig: OauthConfiguration,
+    fun googleTokenVerifier(authConfig: AuthConfiguration,
                             httpTransport: HttpTransport,
                             jsonFactory: JsonFactory): GoogleIdTokenVerifier {
-        return GoogleIdTokenVerifier.Builder(httpTransport, jsonFactory)
-            .setAudience(listOf(oauthConfig.clientId))
-            .build()
+        return authConfig.clientId.map {
+            GoogleIdTokenVerifier.Builder(httpTransport, jsonFactory)
+                .setAudience(listOf(it))
+                .build()
+        }.orElseThrow { IllegalStateException() }
     }
+
+    @Provides
+    @Named(AuthComponent.USERNAME_AUTH)
+    fun usernameAuth(raw: TrivialAuth): Authenticator<String, User> = raw
 
     @Provides
     @Named(AuthComponent.TOKEN_AUTH)

--- a/server/src/main/kotlin/com/github/ptrteixeira/cookbook/auth/TokenAuth.kt
+++ b/server/src/main/kotlin/com/github/ptrteixeira/cookbook/auth/TokenAuth.kt
@@ -6,7 +6,7 @@ import io.dropwizard.auth.Authenticator
 import java.util.Optional
 import javax.inject.Inject
 
-class TokenAuth @Inject constructor(private val googleTokenVerifier: GoogleIdTokenVerifier)
+class TokenAuth @Inject internal constructor(private val googleTokenVerifier: GoogleIdTokenVerifier)
     : Authenticator<String, User> {
     override fun authenticate(credentials: String?): Optional<User> {
         return when (credentials) {

--- a/server/src/main/kotlin/com/github/ptrteixeira/cookbook/auth/TrivialAuth.kt
+++ b/server/src/main/kotlin/com/github/ptrteixeira/cookbook/auth/TrivialAuth.kt
@@ -3,8 +3,9 @@ package com.github.ptrteixeira.cookbook.auth
 import com.github.ptrteixeira.cookbook.core.User
 import io.dropwizard.auth.Authenticator
 import java.util.Optional
+import javax.inject.Inject
 
-class TrivialAuth : Authenticator<String, User> {
+class TrivialAuth @Inject internal constructor() : Authenticator<String, User> {
     override fun authenticate(credentials: String?): Optional<User> {
         return when (credentials) {
             null -> Optional.empty()

--- a/server/src/main/kotlin/com/github/ptrteixeira/cookbook/base/BaseComponent.kt
+++ b/server/src/main/kotlin/com/github/ptrteixeira/cookbook/base/BaseComponent.kt
@@ -2,7 +2,7 @@ package com.github.ptrteixeira.cookbook.base
 
 import com.codahale.metrics.MetricRegistry
 import com.fasterxml.jackson.databind.ObjectMapper
-import com.github.ptrteixeira.cookbook.config.OauthConfiguration
+import com.github.ptrteixeira.cookbook.config.AuthConfiguration
 import com.google.api.client.json.JsonFactory
 import dagger.Component
 import io.dropwizard.db.DataSourceFactory
@@ -18,7 +18,7 @@ interface BaseComponent {
     fun jacksonFactory(): JsonFactory
     fun dataSourceFactory(): DataSourceFactory
     fun metrics(): MetricRegistry
-    fun oauthConfig(): OauthConfiguration
+    fun authConfig(): AuthConfiguration
 
     @Named(BASE_URL)
     fun baseUrl(): String

--- a/server/src/main/kotlin/com/github/ptrteixeira/cookbook/base/BaseModule.kt
+++ b/server/src/main/kotlin/com/github/ptrteixeira/cookbook/base/BaseModule.kt
@@ -5,7 +5,7 @@ import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.datatype.jdk8.Jdk8Module
 import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import com.github.ptrteixeira.cookbook.CookbookConfiguration
-import com.github.ptrteixeira.cookbook.config.OauthConfiguration
+import com.github.ptrteixeira.cookbook.config.AuthConfiguration
 import com.google.api.client.json.JsonFactory
 import com.google.api.client.json.jackson2.JacksonFactory
 import dagger.Module
@@ -35,7 +35,7 @@ internal class BaseModule(
     fun metrics(): MetricRegistry = environment.metrics()
 
     @Provides
-    fun oauthConfig(): OauthConfiguration = config.oauthConfig
+    fun authConfig(): AuthConfiguration = config.auth
 
     @Provides
     @Named(BaseComponent.BASE_URL)

--- a/server/src/main/kotlin/com/github/ptrteixeira/cookbook/config/AuthConfiguration.kt
+++ b/server/src/main/kotlin/com/github/ptrteixeira/cookbook/config/AuthConfiguration.kt
@@ -1,0 +1,8 @@
+package com.github.ptrteixeira.cookbook.config
+
+import java.util.Optional
+
+data class AuthConfiguration(
+    val type: AuthType,
+    val clientId: Optional<String>
+)

--- a/server/src/main/kotlin/com/github/ptrteixeira/cookbook/config/AuthType.kt
+++ b/server/src/main/kotlin/com/github/ptrteixeira/cookbook/config/AuthType.kt
@@ -1,0 +1,6 @@
+package com.github.ptrteixeira.cookbook.config
+
+enum class AuthType {
+    USERNAME,
+    OAUTH
+}

--- a/server/src/main/kotlin/com/github/ptrteixeira/cookbook/config/OauthConfiguration.kt
+++ b/server/src/main/kotlin/com/github/ptrteixeira/cookbook/config/OauthConfiguration.kt
@@ -1,5 +1,0 @@
-package com.github.ptrteixeira.cookbook.config
-
-data class OauthConfiguration(
-    val clientId: String
-)


### PR DESCRIPTION
I had written a psuedo auth filter that I was just using in tests.  This
makes it possible to actually start the application with the other auth
filter. This is principally for integration testing.  However, I will
likely swap the fake auth system to be Basic Auth, which still works
fine for testing and is more than sufficient for self-hosting this
application, which is something that I would like to remain a
possiblity.