### PR TITLE
Fix distribution build process

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,11 +1,12 @@
 buildscript {
-  group = 'com.github.ptrteixeira.cookbook'
-  version = '0.3.0'
-
   repositories {
     mavenCentral()
-    jcenter()
   }
+}
+
+allprojects {
+  group = 'com.github.ptrteixeira.cookbook'
+  version = '0.3.0'
 }
 
 subprojects {

--- a/server/build.gradle
+++ b/server/build.gradle
@@ -40,6 +40,16 @@ spotless {
 mainClassName = "com.github.ptrteixeira.cookbook.CookbookApplicationKt"
 distTar.compression = Compression.GZIP
 
+startScripts {
+  applicationName = "cookbook"
+}
+
+distributions {
+  main {
+    baseName = 'cookbook'
+  }
+}
+
 dependencies {
   compile project(':core')
   compile "io.dropwizard:dropwizard-core:${Dependencies.DROPWIZARD}"


### PR DESCRIPTION
I had inadvertently messed up the name of the output distribution tar
file. I didn't make the version inherit correctly from the root project
to the subprojects, and the build was named after the subproject rather
than the project as a whole. This fixes both issues.