### PR TITLE
Bump version numbers

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -21,10 +21,10 @@ subprojects {
       DROPWIZARD: '1.1.4',
       GOOGLE_API: '1.22.0',
       H2        : '1.4.196',
-      JACKSON   : '2.8.10',
+      JACKSON   : '2.9.1',
       JDBI      : '3.0.0-beta2',
       JERSEY    : '2.25.1',
-      MOCKITO   : '2.9.0',
+      MOCKITO   : '2.10.0',
       SLF4J     : '1.7.25'
   ]
 }

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -3,7 +3,7 @@ buildscript {
     mavenCentral()
   }
   dependencies {
-    classpath 'org.junit.platform:junit-platform-gradle-plugin:1.0.0-RC3'
+    classpath 'org.junit.platform:junit-platform-gradle-plugin:1.0.0'
   }
 }
 

--- a/gradle/junit.gradle
+++ b/gradle/junit.gradle
@@ -1,5 +1,5 @@
 buildscript {
-  ext.junit_version = '5.0.0-RC3'
+  ext.junit_version = '5.0.0'
 }
 
 apply {
@@ -12,5 +12,5 @@ dependencies {
 
   // Vintage systems, required to work with Dropwizard resource tests :c
   testCompile "junit:junit:4.12"
-  testRuntime "org.junit.vintage:junit-vintage-engine:4.12.0-RC3"
+  testRuntime "org.junit.vintage:junit-vintage-engine:4.12.0"
 }

--- a/server/build.gradle
+++ b/server/build.gradle
@@ -3,7 +3,7 @@ buildscript {
     mavenCentral()
   }
   dependencies {
-    classpath 'org.junit.platform:junit-platform-gradle-plugin:1.0.0-RC3'
+    classpath 'org.junit.platform:junit-platform-gradle-plugin:1.0.0'
     classpath 'com.bmuschko:gradle-docker-plugin:3.1.0'
   }
 }


### PR DESCRIPTION
Most important version bump: JUnit 5RC -> 5GA! I just wish they'd
publish the Gradle plugin to the Gradle plugins repo so that it'd be
easier to use now.