### PR TITLE
Roll back Jackson version change

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -21,7 +21,7 @@ subprojects {
       DROPWIZARD: '1.1.4',
       GOOGLE_API: '1.22.0',
       H2        : '1.4.196',
-      JACKSON   : '2.9.1',
+      JACKSON   : '2.8.10',
       JDBI      : '3.0.0-beta2',
       JERSEY    : '2.25.1',
       MOCKITO   : '2.10.0',


### PR DESCRIPTION
Thought that I'd fixed this previously. There's something that breaks if
using Jackson 2.9 + Dropwizard; it is _probably_ a Jackson bug, but I'm
not sure. Staying on 2.8.10 until Dropwizard upgrades is probably the
safest path of action.