### PR TITLE
Add support for Sentry

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -25,6 +25,7 @@ subprojects {
       JDBI      : '3.0.0',
       JERSEY    : '2.25.1',
       MOCKITO   : '2.12.0',
+      SENTRY    : '1.6.3',
       SLF4J     : '1.7.25'
   ]
 }

--- a/cookbook.yml
+++ b/cookbook.yml
@@ -3,6 +3,11 @@ server:
   requestLog:
     appenders:
       - type: console
+logging:
+  appenders:
+    - type: sentry
+      threshold: ERROR
+    - type: console
 baseUrl: ${COOKBOOK_BASE_URL:-"http://localhost:8080"}
 database:
   driverClass: ${DB_DRIVER_CLASS:-org.h2.Driver}

--- a/server/build.gradle
+++ b/server/build.gradle
@@ -56,6 +56,7 @@ dependencies {
   compile "io.dropwizard:dropwizard-jdbi:${Dependencies.DROPWIZARD}"
   compile "io.dropwizard:dropwizard-migrations:${Dependencies.DROPWIZARD}"
   compile "io.dropwizard:dropwizard-auth:${Dependencies.DROPWIZARD}"
+  compile "io.sentry:sentry-logback:${Dependencies.SENTRY}"
   compile "org.jdbi:jdbi3-kotlin-sqlobject:${Dependencies.JDBI}"
   compile "com.fasterxml.jackson.module:jackson-module-kotlin:${Dependencies.JACKSON}"
   compile "com.fasterxml.jackson.datatype:jackson-datatype-jdk8:${Dependencies.JACKSON}"

--- a/server/src/main/kotlin/com/github/ptrteixeira/cookbook/resources/RecipesResource.kt
+++ b/server/src/main/kotlin/com/github/ptrteixeira/cookbook/resources/RecipesResource.kt
@@ -5,6 +5,7 @@ import com.github.ptrteixeira.cookbook.core.RecipeEgg
 import com.github.ptrteixeira.cookbook.core.User
 import com.github.ptrteixeira.cookbook.data.RecipeData
 import io.dropwizard.auth.Auth
+import org.slf4j.LoggerFactory
 import java.util.Optional
 import javax.inject.Inject
 import javax.ws.rs.DELETE
@@ -49,5 +50,9 @@ internal class RecipesResource @Inject constructor(
     @Path("/{id}")
     fun deleteRecipe(@Auth user: User, @PathParam("id") id: Int) {
         recipeData.deleteRecipe(user, id)
+    }
+
+    companion object {
+        private val LOGGER = LoggerFactory.getLogger(RecipesResource::class.java)
     }
 }

--- a/server/src/main/kotlin/com/github/ptrteixeira/cookbook/sentry/SentryAppenderFactory.kt
+++ b/server/src/main/kotlin/com/github/ptrteixeira/cookbook/sentry/SentryAppenderFactory.kt
@@ -1,0 +1,39 @@
+package com.github.ptrteixeira.cookbook.sentry
+
+import ch.qos.logback.classic.LoggerContext
+import ch.qos.logback.classic.spi.ILoggingEvent
+import ch.qos.logback.core.Appender
+import ch.qos.logback.core.encoder.LayoutWrappingEncoder
+import ch.qos.logback.core.filter.Filter
+import com.fasterxml.jackson.annotation.JsonTypeName
+import io.dropwizard.logging.AbstractAppenderFactory
+import io.dropwizard.logging.async.AsyncAppenderFactory
+import io.dropwizard.logging.filter.LevelFilterFactory
+import io.dropwizard.logging.layout.LayoutFactory
+import io.sentry.logback.SentryAppender
+
+@JsonTypeName("sentry")
+class SentryAppenderFactory : AbstractAppenderFactory<ILoggingEvent>() {
+
+    override fun build(context: LoggerContext, applicationName: String,
+                       layoutFactory: LayoutFactory<ILoggingEvent>,
+                       levelFilterFactory: LevelFilterFactory<ILoggingEvent>,
+                       asyncAppenderFactory: AsyncAppenderFactory<ILoggingEvent>): Appender<ILoggingEvent> {
+        val appender = SentryAppender()
+        appender.name = "sentry-appender"
+        appender.context = context
+
+        val layoutEncoder = LayoutWrappingEncoder<ILoggingEvent>()
+        layoutEncoder.layout = buildLayout(context, layoutFactory)
+        val filter: Filter<ILoggingEvent> = levelFilterFactory
+            .build(threshold)
+        filterFactories.forEach {
+            appender.addFilter(it.build())
+        }
+
+        appender.addFilter(filter)
+        appender.start()
+
+        return wrapAsync(appender, asyncAppenderFactory)
+    }
+}

--- a/server/src/main/resources/META-INF/services/io.dropwizard.logging.AppenderFactory
+++ b/server/src/main/resources/META-INF/services/io.dropwizard.logging.AppenderFactory
@@ -1,0 +1,1 @@
+com.github.ptrteixeira.cookbook.sentry.SentryAppenderFactory

--- a/server/src/main/resources/sentry.properties
+++ b/server/src/main/resources/sentry.properties
@@ -1,0 +1,1 @@
+stacktrace.app.packages=com.github.ptrteixeira.cookbook

--- a/server/src/test/kotlin/com/github/ptrteixeira/cookbook/sentry/SentryAppenderFactoryTest.kt
+++ b/server/src/test/kotlin/com/github/ptrteixeira/cookbook/sentry/SentryAppenderFactoryTest.kt
@@ -1,0 +1,20 @@
+package com.github.ptrteixeira.cookbook.sentry
+
+import io.dropwizard.jackson.DiscoverableSubtypeResolver
+import io.dropwizard.logging.BootstrapLogging
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+internal class SentryAppenderFactoryTest {
+    @BeforeEach
+    fun init() {
+        BootstrapLogging.bootstrap()
+    }
+
+    @Test
+    fun isDiscoverable() {
+        assertThat(DiscoverableSubtypeResolver().discoveredSubtypes)
+            .contains(SentryAppenderFactory::class.java)
+    }
+}


### PR DESCRIPTION
Add support for using Sentry for error logging. An alternative might be using Rollbar (or whatever), but I have some experience with Sentry, so did that instead. This was something that I had planned on doing for a while, but didn't expect to do for a while. But front-end dev work makes me sleepy sometimes, so I took a break from that to do this instead.