### PR TITLE
Report metrics for application

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -23,6 +23,7 @@ subprojects {
       JACKSON   : '2.9.6',
       JDBI      : '3.3.0',
       JERSEY    : '2.25.1',
+      MICROMETER: '1.0.6',
       MOCKITO   : '2.21.0',
       RETROFIT  : '2.4.0',
       RXJAVA    : '2.2.0',

--- a/dev.conf
+++ b/dev.conf
@@ -20,4 +20,16 @@ server {
   location /api/ {
     proxy_pass http://punchcard_backend/;
   }
+
+  location /api/metrics {
+    error_page 403 = @blocked;
+    allow 127.0.0.1;
+    deny all;
+
+    proxy_pass http://punchcard_backend/metrics/;
+  }
+
+  location @blocked {
+    return 404;
+  }
 }

--- a/punchcard-server/build.gradle
+++ b/punchcard-server/build.gradle
@@ -45,6 +45,8 @@ dependencies {
   compile project(':strava-api')
   compile "io.dropwizard:dropwizard-core:${Dependencies.DROPWIZARD}"
   compile "io.sentry:sentry-logback:${Dependencies.SENTRY}"
+  compile "io.micrometer:micrometer-core:${Dependencies.MICROMETER}"
+  compile "io.micrometer:micrometer-registry-prometheus:${Dependencies.MICROMETER}"
   compile "com.fasterxml.jackson.module:jackson-module-kotlin:${Dependencies.JACKSON}"
   compile "com.fasterxml.jackson.datatype:jackson-datatype-jdk8:${Dependencies.JACKSON}"
   compile "com.squareup.retrofit2:adapter-rxjava2:${Dependencies.RETROFIT}"

--- a/punchcard-server/src/main/kotlin/com/github/ptrteixeira/punchcard/resources/MetricsResource.kt
+++ b/punchcard-server/src/main/kotlin/com/github/ptrteixeira/punchcard/resources/MetricsResource.kt
@@ -1,0 +1,13 @@
+package com.github.ptrteixeira.punchcard.resources
+
+import io.micrometer.prometheus.PrometheusMeterRegistry
+import javax.ws.rs.GET
+import javax.ws.rs.Path
+
+@Path("/metrics")
+class MetricsResource(private val registry: PrometheusMeterRegistry) {
+    @GET
+    fun reportMetrics(): String {
+        return registry.scrape()
+    }
+}


### PR DESCRIPTION
Adds an endpoint to report metrics in Prometheus format.

Some thoughts:
* Why I chose Prometheus - it's CNCF hosted. If I was gonna pick something to report metrics to, that was gonna be it.
* As it happened, though, Prometheus was a good option. I'm not actually *running* a metric server, which means that push metric clients aren't reporting metrics anywhere. Conversely, if I need metrics I can just curl the metrics endpoint
* I'm definitely not monitoring the right things at the moment; what I'm doing is basically a shim for reporting traces. But this is good enough for the moment.
* Not pleased with the metrics endpoint itself. In an ideal world, it would live on the admin port rather than the main port, because it's an admin thing and not a main thing and shouldn't be exposed to the user. But Dropwizard doesn't make it particularly easy to add extra endpoints to the admin port (and I couldn't just add a task because tasks are all POST requests). So I added to the main endpoint and just blocked access from things that aren't `127.0.0.1`. But, uh, still not real pleased.