### PR TITLE
Convert from RxJava2 to Reactor

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -15,19 +15,21 @@ subprojects {
   }
 
   ext.Dependencies = [
-      ASSERTJ   : '3.10.0',
-      DAGGER    : '2.17',
-      DROPWIZARD: '1.3.5',
-      GOOGLE_API: '1.23.0',
-      H2        : '1.4.197',
-      JACKSON   : '2.9.6',
-      JDBI      : '3.3.0',
-      JERSEY    : '2.25.1',
-      MICROMETER: '1.0.6',
-      MOCKITO   : '2.21.0',
-      RETROFIT  : '2.4.0',
-      RXJAVA    : '2.2.0',
-      SENTRY    : '1.7.5',
-      SLF4J     : '1.7.25'
+      ASSERTJ                  : '3.10.0',
+      DAGGER                   : '2.17',
+      DROPWIZARD               : '1.3.5',
+      GOOGLE_API               : '1.23.0',
+      H2                       : '1.4.197',
+      JACKSON                  : '2.9.6',
+      JDBI                     : '3.3.0',
+      JERSEY                   : '2.25.1',
+      MICROMETER               : '1.0.6',
+      MOCKITO                  : '2.21.0',
+      REACTOR                  : '3.1.8.RELEASE',
+      RETROFIT                 : '2.4.0',
+      RETROFIT_REACTOR_ADAPTER : '2.1.0',
+      RXJAVA                   : '2.2.0',
+      SENTRY                   : '1.7.5',
+      SLF4J                    : '1.7.25'
   ]
 }

--- a/build.gradle
+++ b/build.gradle
@@ -16,6 +16,7 @@ subprojects {
 
   ext.Dependencies = [
       ASSERTJ                  : '3.10.0',
+      COROUTINES               : '0.25.0',
       DAGGER                   : '2.17',
       DROPWIZARD               : '1.3.5',
       GOOGLE_API               : '1.23.0',

--- a/punchcard-server/build.gradle
+++ b/punchcard-server/build.gradle
@@ -51,6 +51,8 @@ dependencies {
   compile "com.fasterxml.jackson.datatype:jackson-datatype-jdk8:${Dependencies.JACKSON}"
   compile "com.jakewharton.retrofit:retrofit2-reactor-adapter:${Dependencies.RETROFIT_REACTOR_ADAPTER}"
   compile "com.squareup.retrofit2:converter-jackson:${Dependencies.RETROFIT}"
+  compile "org.jetbrains.kotlinx:kotlinx-coroutines-core:${Dependencies.COROUTINES}"
+  compile "org.jetbrains.kotlinx:kotlinx-coroutines-reactive:${Dependencies.COROUTINES}"
 
   testCompile "org.assertj:assertj-core:${Dependencies.ASSERTJ}"
   testCompile "io.dropwizard:dropwizard-testing:${Dependencies.DROPWIZARD}"

--- a/punchcard-server/build.gradle
+++ b/punchcard-server/build.gradle
@@ -49,7 +49,7 @@ dependencies {
   compile "io.micrometer:micrometer-registry-prometheus:${Dependencies.MICROMETER}"
   compile "com.fasterxml.jackson.module:jackson-module-kotlin:${Dependencies.JACKSON}"
   compile "com.fasterxml.jackson.datatype:jackson-datatype-jdk8:${Dependencies.JACKSON}"
-  compile "com.squareup.retrofit2:adapter-rxjava2:${Dependencies.RETROFIT}"
+  compile "com.jakewharton.retrofit:retrofit2-reactor-adapter:${Dependencies.RETROFIT_REACTOR_ADAPTER}"
   compile "com.squareup.retrofit2:converter-jackson:${Dependencies.RETROFIT}"
 
   testCompile "org.assertj:assertj-core:${Dependencies.ASSERTJ}"

--- a/punchcard-server/src/main/kotlin/com/github/ptrteixeira/punchcard/StravaPunchcardApplication.kt
+++ b/punchcard-server/src/main/kotlin/com/github/ptrteixeira/punchcard/StravaPunchcardApplication.kt
@@ -19,11 +19,13 @@ import io.micrometer.prometheus.PrometheusConfig
 import io.micrometer.prometheus.PrometheusMeterRegistry
 import retrofit2.Retrofit
 import retrofit2.converter.jackson.JacksonConverterFactory
+import java.time.Clock
 
 class StravaPunchcardApplication : Application<StravaPunchcardConfiguration>() {
     override fun run(configuration: StravaPunchcardConfiguration, environment: Environment) {
         val objectMapper = jacksonObjectMapper()
         val stravaApi = strava(objectMapper)
+        val stravaService = StravaService(stravaApi)
         val registry = meterRegistry()
 
         configure(environment) {
@@ -33,11 +35,12 @@ class StravaPunchcardApplication : Application<StravaPunchcardConfiguration>() {
                             dashboardUiUrl = configuration.dashboardUiUrl,
                             clientId = configuration.stravaClientId,
                             clientSecret = configuration.stravaClientSecret,
-                            apiClient = stravaApi,
+                            stravaService = stravaService,
                             registry = registry
                     ),
                     PunchcardResource(
-                            strava = StravaService(stravaApi),
+                            strava = stravaService,
+                            clock = Clock.systemUTC(),
                             registry = registry
                     ),
                     MetricsResource(registry = registry)

--- a/punchcard-server/src/main/kotlin/com/github/ptrteixeira/punchcard/StravaPunchcardApplication.kt
+++ b/punchcard-server/src/main/kotlin/com/github/ptrteixeira/punchcard/StravaPunchcardApplication.kt
@@ -8,6 +8,7 @@ import com.github.ptrteixeira.punchcard.resources.MetricsResource
 import com.github.ptrteixeira.punchcard.resources.PunchcardResource
 import com.github.ptrteixeira.strava.api.StravaApi
 import com.github.ptrteixeira.strava.api.StravaService
+import com.jakewharton.retrofit2.adapter.reactor.ReactorCallAdapterFactory
 import io.dropwizard.Application
 import io.dropwizard.setup.Environment
 import io.micrometer.core.instrument.binder.jvm.JvmGcMetrics
@@ -17,7 +18,6 @@ import io.micrometer.core.instrument.binder.system.ProcessorMetrics
 import io.micrometer.prometheus.PrometheusConfig
 import io.micrometer.prometheus.PrometheusMeterRegistry
 import retrofit2.Retrofit
-import retrofit2.adapter.rxjava2.RxJava2CallAdapterFactory
 import retrofit2.converter.jackson.JacksonConverterFactory
 
 class StravaPunchcardApplication : Application<StravaPunchcardConfiguration>() {
@@ -63,7 +63,7 @@ class StravaPunchcardApplication : Application<StravaPunchcardConfiguration>() {
         val retrofit = Retrofit.Builder()
                 .baseUrl("https://www.strava.com/api/v3/")
                 .addConverterFactory(JacksonConverterFactory.create(objectMapper))
-                .addCallAdapterFactory(RxJava2CallAdapterFactory.create())
+                .addCallAdapterFactory(ReactorCallAdapterFactory.create())
                 .build()
         return retrofit
                 .create(StravaApi::class.java)

--- a/punchcard-server/src/main/kotlin/com/github/ptrteixeira/punchcard/resources/AuthResource.kt
+++ b/punchcard-server/src/main/kotlin/com/github/ptrteixeira/punchcard/resources/AuthResource.kt
@@ -80,7 +80,7 @@ class AuthResource(
                 .getAuthToken(clientId, clientSecret, code)
                 .map { it.accessToken }
                 .map { buildAuthCookie(it) }
-                .blockingGet()
+                .block()
 
         successfulLoginAttempts.increment()
         return Response.seeOther(URI(dashboardUiUrl))

--- a/punchcard-server/src/main/kotlin/com/github/ptrteixeira/punchcard/resources/AuthResource.kt
+++ b/punchcard-server/src/main/kotlin/com/github/ptrteixeira/punchcard/resources/AuthResource.kt
@@ -1,8 +1,10 @@
 package com.github.ptrteixeira.punchcard.resources
 
 import com.github.ptrteixeira.punchcard.StravaPunchcardModule
-import com.github.ptrteixeira.strava.api.StravaApi
+import com.github.ptrteixeira.strava.api.IStravaService
 import io.micrometer.core.instrument.MeterRegistry
+import kotlinx.coroutines.experimental.reactive.awaitFirst
+import kotlinx.coroutines.experimental.runBlocking
 import org.slf4j.LoggerFactory
 import java.net.URI
 import java.util.Random
@@ -26,7 +28,7 @@ class AuthResource(
     private val dashboardUiUrl: String,
     private val clientId: String,
     private val clientSecret: String,
-    private val apiClient: StravaApi,
+    private val stravaService: IStravaService,
     registry: MeterRegistry
 ) {
     private val random = Random()
@@ -76,16 +78,15 @@ class AuthResource(
                     .build()
         }
 
-        val cookie = apiClient
-                .getAuthToken(clientId, clientSecret, code)
-                .map { it.accessToken }
-                .map { buildAuthCookie(it) }
-                .block()
+        return runBlocking {
+            val authToken = stravaService.getAuthToken(clientId, clientSecret, code)
+            val cookie = buildAuthCookie(authToken.awaitFirst().accessToken)
 
-        successfulLoginAttempts.increment()
-        return Response.seeOther(URI(dashboardUiUrl))
-                .cookie(cookie)
-                .build()
+            successfulLoginAttempts.increment()
+            return@runBlocking Response.seeOther(URI(dashboardUiUrl))
+                    .cookie(cookie)
+                    .build()
+        }
     }
 
     private fun buildAuthCookie(value: String) = NewCookie(

--- a/punchcard-server/src/main/kotlin/com/github/ptrteixeira/punchcard/resources/PunchcardResource.kt
+++ b/punchcard-server/src/main/kotlin/com/github/ptrteixeira/punchcard/resources/PunchcardResource.kt
@@ -6,8 +6,9 @@ import com.github.ptrteixeira.strava.api.models.AthleteActivitiesResponse
 import com.google.common.base.Stopwatch
 import io.micrometer.core.instrument.MeterRegistry
 import io.micrometer.core.instrument.Timer
-import io.reactivex.Observable
-import io.reactivex.observables.GroupedObservable
+import reactor.core.publisher.Flux
+import reactor.core.publisher.GroupedFlux
+import reactor.core.publisher.toFlux
 import java.time.DayOfWeek
 import java.time.Duration
 import java.time.LocalDateTime
@@ -89,11 +90,11 @@ class PunchcardResource(
         return DayAndHourRollup(startTime.dayOfWeek, startTime.hour)
     }
 
-    private fun <K, T> countItems(itemStream: GroupedObservable<K, T>): Observable<Pair<K?, Long>> {
+    private fun <K, T> countItems(itemStream: GroupedFlux<K, T>): Flux<Pair<K, Long>> {
         return itemStream
                 .count()
-                .toObservable()
-                .map { count -> itemStream.key to count }
+                .toFlux()
+                .map { count -> itemStream.key() to count }
     }
 
     private fun mapCollector(): MutableMap<DayOfWeek, MutableMap<Int, Long>> {

--- a/punchcard-server/src/test/kotlin/com/github/ptrteixeira/punchcard/resources/PunchcardResourceTest.kt
+++ b/punchcard-server/src/test/kotlin/com/github/ptrteixeira/punchcard/resources/PunchcardResourceTest.kt
@@ -1,0 +1,101 @@
+package com.github.ptrteixeira.punchcard.resources
+
+import com.github.ptrteixeira.strava.api.IStravaService
+import com.github.ptrteixeira.strava.api.models.AthleteActivitiesResponse
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry
+import org.junit.Before
+import org.junit.Test
+import org.mockito.ArgumentMatchers.any
+import org.mockito.BDDMockito.given
+import org.mockito.BDDMockito.then
+import org.mockito.Mockito.mock
+import reactor.core.publisher.Flux
+import java.time.Clock
+import java.time.DayOfWeek
+import java.time.Instant
+import java.time.LocalDateTime
+import java.time.ZoneOffset
+import java.time.ZonedDateTime
+import java.time.format.DateTimeFormatter
+import java.time.temporal.ChronoField
+import java.time.temporal.ChronoUnit
+import java.util.concurrent.TimeoutException
+import javax.ws.rs.container.AsyncResponse
+
+class PunchcardResourceTest {
+    private val testClock = Clock.fixed(Instant.EPOCH, ZoneOffset.UTC)
+    private val queryStartDate = LocalDateTime.now(testClock).minus(6, ChronoUnit.MONTHS)
+
+    lateinit var punchcardResource: PunchcardResource
+    lateinit var stravaService: IStravaService
+    lateinit var asyncResponse: AsyncResponse
+
+    @Before
+    fun setUp() {
+        stravaService = mock(IStravaService::class.java)
+        asyncResponse = mock(AsyncResponse::class.java)
+
+        punchcardResource = PunchcardResource(stravaService, testClock, SimpleMeterRegistry())
+    }
+
+    @Test
+    fun `when there are no activities it returns an empty map`() {
+        given(stravaService.getAthleteActivities("", queryStartDate))
+                .willReturn(Flux.empty())
+
+        punchcardResource
+                .getActivities("", asyncResponse)
+
+        then(asyncResponse)
+                .should()
+                .resume(emptyMap<DayOfWeek, Map<Int, Long>>())
+    }
+
+    @Test
+    fun `when it receives an http error it propagates that error`() {
+        given(stravaService.getAthleteActivities("", queryStartDate))
+                .willReturn(Flux.error(TimeoutException()))
+
+        punchcardResource
+                .getActivities("", asyncResponse)
+
+        then(asyncResponse)
+                .should()
+                .resume(any<TimeoutException>())
+    }
+
+    @Test
+    fun `when it finds activities it adds them to the returned map`() {
+        given(stravaService.getAthleteActivities("", queryStartDate))
+                .willReturn(Flux.just(
+                        activityAtTime(DayOfWeek.MONDAY, 18),
+                        activityAtTime(DayOfWeek.MONDAY, 18),
+                        activityAtTime(DayOfWeek.SUNDAY, 9)
+                ))
+
+        punchcardResource
+                .getActivities("", asyncResponse)
+
+        val resultMap = mapOf(
+                DayOfWeek.MONDAY to mapOf(18 to 2.toLong()),
+                DayOfWeek.SUNDAY to mapOf(9 to 1.toLong())
+        )
+        then(asyncResponse)
+                .should()
+                .resume(resultMap)
+    }
+
+    private fun activityAtTime(day: DayOfWeek, hour: Int): AthleteActivitiesResponse {
+        val activityStartTime = ZonedDateTime.now(testClock)
+                .with(day)
+                .with(ChronoField.HOUR_OF_DAY, hour.toLong())
+
+        val timeAsString = activityStartTime
+                .format(DateTimeFormatter.ISO_OFFSET_DATE_TIME)
+
+        return AthleteActivitiesResponse(
+                startDate = timeAsString,
+                startDateLocal = timeAsString
+        )
+    }
+}

--- a/strava-api/build.gradle
+++ b/strava-api/build.gradle
@@ -1,6 +1,5 @@
 plugins {
   id 'nebula.kotlin' version '1.2.60'
-  id 'org.jetbrains.kotlin.jvm' version '1.2.60'
   id 'com.diffplug.gradle.spotless' version '3.14.0'
 }
 
@@ -18,7 +17,6 @@ spotless {
 dependencies {
   compile "com.squareup.retrofit2:retrofit:${Dependencies.RETROFIT}"
   compile "io.projectreactor:reactor-core:${Dependencies.REACTOR}"
-  compile "com.jakewharton.retrofit:retrofit2-reactor-adapter:${Dependencies.RETROFIT_REACTOR_ADAPTER}"
 
   implementation "com.fasterxml.jackson.datatype:jackson-datatype-jdk8:${Dependencies.JACKSON}"
   implementation "com.fasterxml.jackson.core:jackson-annotations:${Dependencies.JACKSON}"

--- a/strava-api/build.gradle
+++ b/strava-api/build.gradle
@@ -17,11 +17,13 @@ spotless {
 
 dependencies {
   compile "com.squareup.retrofit2:retrofit:${Dependencies.RETROFIT}"
-  compile "io.reactivex.rxjava2:rxjava:${Dependencies.RXJAVA}"
+  compile "io.projectreactor:reactor-core:${Dependencies.REACTOR}"
+  compile "com.jakewharton.retrofit:retrofit2-reactor-adapter:${Dependencies.RETROFIT_REACTOR_ADAPTER}"
 
   implementation "com.fasterxml.jackson.datatype:jackson-datatype-jdk8:${Dependencies.JACKSON}"
   implementation "com.fasterxml.jackson.core:jackson-annotations:${Dependencies.JACKSON}"
   implementation "com.fasterxml.jackson.module:jackson-module-kotlin:${Dependencies.JACKSON}"
 
   testCompile "org.mockito:mockito-core:${Dependencies.MOCKITO}"
+  testCompile "io.projectreactor:reactor-test:${Dependencies.REACTOR}"
 }

--- a/strava-api/src/main/kotlin/IStravaService.kt
+++ b/strava-api/src/main/kotlin/IStravaService.kt
@@ -1,0 +1,16 @@
+package com.github.ptrteixeira.strava.api
+
+import com.github.ptrteixeira.strava.api.models.AthleteActivitiesResponse
+import com.github.ptrteixeira.strava.api.models.TokenResponse
+import reactor.core.publisher.Flux
+import reactor.core.publisher.Mono
+import java.time.LocalDateTime
+
+interface IStravaService {
+    fun getAthleteActivities(
+        authToken: String,
+        after: LocalDateTime
+    ): Flux<AthleteActivitiesResponse>
+
+    fun getAuthToken(clientId: String, clientSecret: String, code: String): Mono<TokenResponse>
+}

--- a/strava-api/src/main/kotlin/StravaApi.kt
+++ b/strava-api/src/main/kotlin/StravaApi.kt
@@ -2,7 +2,7 @@ package com.github.ptrteixeira.strava.api
 
 import com.github.ptrteixeira.strava.api.models.AthleteActivitiesResponse
 import com.github.ptrteixeira.strava.api.models.TokenResponse
-import io.reactivex.Single
+import reactor.core.publisher.Mono
 import retrofit2.http.GET
 import retrofit2.http.Header
 import retrofit2.http.POST
@@ -16,14 +16,14 @@ interface StravaApi {
         @Query("after") after: Long,
         @Query("page") page: Int = 1,
         @Query("per_page") itemsPerPage: Int = 30
-    ): Single<List<AthleteActivitiesResponse>>
+    ): Mono<List<AthleteActivitiesResponse>>
 
     @GET("athlete/activities")
     fun getAthleteActivities(
         @Header("authorization") authHeader: String,
         @Query("page") page: Int = 1,
         @Query("per_page") itemsPerPage: Int = 30
-    ): Single<List<AthleteActivitiesResponse>>
+    ): Mono<List<AthleteActivitiesResponse>>
 
     @GET("athlete/activities")
     fun getAthleteActivities(
@@ -31,12 +31,12 @@ interface StravaApi {
         @Query("after") after: Long,
         @Query("page") page: Int = 1,
         @Query("per_page") itemsPerPage: Int = 30
-    ): Single<List<AthleteActivitiesResponse>>
+    ): Mono<List<AthleteActivitiesResponse>>
 
     @POST("https://www.strava.com/oauth/token")
     fun getAuthToken(
         @Query("client_id") clientId: String,
         @Query("client_secret") clientSecret: String,
         @Query("code") code: String
-    ): Single<TokenResponse>
+    ): Mono<TokenResponse>
 }

--- a/strava-api/src/main/kotlin/StravaService.kt
+++ b/strava-api/src/main/kotlin/StravaService.kt
@@ -7,15 +7,15 @@ import reactor.core.publisher.Mono
 import java.time.LocalDateTime
 import java.time.ZoneOffset
 
-open class StravaService(private val strava: StravaApi) {
-    fun getAthleteActivities(
+class StravaService(private val strava: StravaApi) : IStravaService {
+    override fun getAthleteActivities(
         authToken: String,
         after: LocalDateTime
     ): Flux<AthleteActivitiesResponse> {
-        return getAthleteActivities(authToken, 1, after)
+        return getAthleteActivities(authToken, page = 1, after = after)
     }
 
-    fun getAuthToken(clientId: String, clientSecret: String, code: String): Mono<TokenResponse> {
+    override fun getAuthToken(clientId: String, clientSecret: String, code: String): Mono<TokenResponse> {
         return strava.getAuthToken(clientId, clientSecret, code)
     }
 


### PR DESCRIPTION
Just cause. My understanding from the RxJava folks is that if you aren't
targeting Android, you should prefer Reactor over RxJava because it's
slightly lighter-weight. So trying this out.