### PR TITLE
Rewrite the CI configuration

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ jobs:
   build:
     working_directory: ~/cookbook
     docker:
-      - image: openjdk:8u151
+      - image: circleci/openjdk:8u181-jdk-node-browsers
     environment:
       _JAVA_OPTIONS: -Xmx1024m -XX:ParallelGCThreads=2 -XX:ConcGCThreads=2 -XX:ParallelGCThreads=2 -Djava.util.concurrent.ForkJoinPool.common.parallelism=2
     steps:
@@ -11,14 +11,15 @@ jobs:
       - restore_cache:
           key: v1-{{ checksum "build.gradle" }}
       - run: |
-              bash gradlew check -Pkotlin.incremental=false --no-daemon 
+              bash gradlew check
+      - run: |
+              cd punchcard-ui
+              yarn
+              yarn test
+              cd ~/cookbook
       - save_cache:
           paths:
             - ~/.m2
           key: v1-{{ checksum "build.gradle" }}
       - store_test_results:
-          path: server/build/test-results
-      - store_test_results:
-          path: core/build/test-results
-      - store_test_results:
-          path: kotlin-dropwizard-dsl/build/test-results
+          path: ~/cookbook/build/reports/allTestsXml

--- a/build.gradle
+++ b/build.gradle
@@ -15,22 +15,22 @@ subprojects {
   }
 
   ext.Dependencies = [
-      ASSERTJ                  : '3.10.0',
-      COROUTINES               : '0.25.0',
-      DAGGER                   : '2.17',
-      DROPWIZARD               : '1.3.5',
-      GOOGLE_API               : '1.23.0',
-      H2                       : '1.4.197',
-      JACKSON                  : '2.9.6',
-      JDBI                     : '3.3.0',
-      JERSEY                   : '2.25.1',
-      MICROMETER               : '1.0.6',
-      MOCKITO                  : '2.21.0',
-      REACTOR                  : '3.1.8.RELEASE',
-      RETROFIT                 : '2.4.0',
-      RETROFIT_REACTOR_ADAPTER : '2.1.0',
-      RXJAVA                   : '2.2.0',
-      SENTRY                   : '1.7.5',
-      SLF4J                    : '1.7.25'
+      ASSERTJ                 : '3.10.0',
+      COROUTINES              : '0.25.0',
+      DAGGER                  : '2.17',
+      DROPWIZARD              : '1.3.5',
+      GOOGLE_API              : '1.23.0',
+      H2                      : '1.4.197',
+      JACKSON                 : '2.9.6',
+      JDBI                    : '3.3.0',
+      JERSEY                  : '2.25.1',
+      MICROMETER              : '1.0.6',
+      MOCKITO                 : '2.21.0',
+      REACTOR                 : '3.1.8.RELEASE',
+      RETROFIT                : '2.4.0',
+      RETROFIT_REACTOR_ADAPTER: '2.1.0',
+      RXJAVA                  : '2.2.0',
+      SENTRY                  : '1.7.5',
+      SLF4J                   : '1.7.25'
   ]
 }

--- a/gradle/junit.gradle
+++ b/gradle/junit.gradle
@@ -5,12 +5,15 @@ buildscript {
 test {
   useJUnitPlatform()
 
-  testLogging {
-    events 'skipped', 'failed'
-  }
-
   reports {
-    html.enabled = true
+    junitXml.configure {
+      enabled = true
+      destination = new File(rootProject.buildDir, "/reports/allTestsXml/${project.name}")
+    }
+
+    html.configure {
+      enabled = false
+    }
   }
 }
 

--- a/punchcard-ui/package.json
+++ b/punchcard-ui/package.json
@@ -30,6 +30,7 @@
     "@types/node": "^10.3.5",
     "@types/react": "^16.4.1",
     "@types/react-dom": "^16.0.6",
+    "jest-localstorage-mock": "^2.2.0",
     "typescript": "^2.9.2"
   }
 }

--- a/punchcard-ui/src/App.test.tsx
+++ b/punchcard-ui/src/App.test.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
 import * as ReactDOM from 'react-dom';
+import 'jest-localstorage-mock';
 import App from './App';
 
 it('renders without crashing', () => {

--- a/punchcard-ui/yarn.lock
+++ b/punchcard-ui/yarn.lock
@@ -3872,6 +3872,10 @@ jest-leak-detector@^22.4.0:
   dependencies:
     pretty-format "^22.4.3"
 
+jest-localstorage-mock@^2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/jest-localstorage-mock/-/jest-localstorage-mock-2.2.0.tgz#ce9a9de01dfdde2ad8aa08adf73acc7e5cc394cf"
+
 jest-matcher-utils@^22.4.0, jest-matcher-utils@^22.4.3:
   version "22.4.3"
   resolved "https://registry.yarnpkg.com/jest-matcher-utils/-/jest-matcher-utils-22.4.3.tgz#4632fe428ebc73ebc194d3c7b65d37b161f710ff"


### PR DESCRIPTION
Couple things needed to change here. 

1. Test results were never being saved by CircleCI; the directories that I had pointed the config to no longer existed. The current system would have meant adding a new config item for each new project and renaming things when they changed, and I'm not even sure that it'd work. This saves all the test results in a centralized location, which is much more sustainable.
2. The UI tests weren't running on CI. This was problematic. It also required using a different base image, because I wanted node / yarn pre-installed.

Anyways, /closes #76