### PR TITLE
Enable HTTPS on the Dropwizard server

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -32,6 +32,7 @@ subprojects {
 
     extra["versions"] = mapOf(
             "ASSERTJ" to "3.11.1",
+            "CONSCRYPT" to "1.4.1",
             "COROUTINES" to "1.0.0",
             "DAGGER" to "2.19",
             "DROPWIZARD_DAGGER" to "0.1.0-alpha03",

--- a/punchcard-server/.gitignore
+++ b/punchcard-server/.gitignore
@@ -1,0 +1,3 @@
+.env
+*.keystore
+

--- a/punchcard-server/build.gradle.kts
+++ b/punchcard-server/build.gradle.kts
@@ -29,7 +29,10 @@ dependencies {
     compile(project(":sentry-appender"))
     compile(project(":strava-api"))
     compile(kotlin("stdlib-jdk8"))
-    compile("io.dropwizard", "dropwizard-core", versions["DROPWIZARD"])
+
+    compile("io.dropwizard", "dropwizard-bom", versions["DROPWIZARD"])
+    compile("io.dropwizard", "dropwizard-core")
+    compile("io.dropwizard", "dropwizard-http2")
     compile("io.sentry", "sentry-logback", versions["SENTRY"])
     compile("io.micrometer", "micrometer-core", versions["MICROMETER"])
     compile("io.micrometer", "micrometer-registry-prometheus", versions["MICROMETER"])
@@ -37,6 +40,8 @@ dependencies {
     compile("com.fasterxml.jackson.datatype", "jackson-datatype-jdk8", versions["JACKSON"])
     compile("com.jakewharton.retrofit", "retrofit2-reactor-adapter", versions["RETROFIT_REACTOR_ADAPTER"])
     compile("com.squareup.retrofit2", "converter-jackson", versions["RETROFIT"])
+    compile("org.conscrypt", "conscrypt-openjdk-uber", versions["CONSCRYPT"])
+    compile("org.eclipse.jetty", "jetty-alpn-conscrypt-server")
     compile("org.jetbrains.kotlinx", "kotlinx-coroutines-core", versions["COROUTINES"])
     compile("org.jetbrains.kotlinx", "kotlinx-coroutines-reactive", versions["COROUTINES"])
     compile("com.google.dagger", "dagger", versions["DAGGER"])
@@ -44,8 +49,8 @@ dependencies {
     kapt("com.google.dagger", "dagger-compiler", versions["DAGGER"])
 
     testCompile("org.assertj", "assertj-core", versions["ASSERTJ"])
-    testCompile("io.dropwizard", "dropwizard-testing", versions["DROPWIZARD"])
-    testCompile("org.glassfish.jersey.test-framework.providers", "jersey-test-framework-provider-grizzly2", versions["JERSEY"]) {
+    testCompile("io.dropwizard", "dropwizard-testing")
+    testCompile("org.glassfish.jersey.test-framework.providers", "jersey-test-framework-provider-grizzly2") {
         exclude(group = "junit", module = "junit")
         exclude(group = "javax.servlet", module = "javax.servlet-api")
     }

--- a/punchcard-server/punchcard.test.yml
+++ b/punchcard-server/punchcard.test.yml
@@ -1,0 +1,18 @@
+baseUrl: "https://localhost:8080"
+dashboardUiUrl: "https://localhost:3000"
+stravaClientId: "${STRAVA_CLIENT_ID}"
+stravaClientSecret: "${STRAVA_CLIENT_SECRET}"
+
+server:
+  applicationConnectors:
+  - type: "h2"
+    port: 8443
+    jceProvider: "Conscrypt"
+    httpCompliance: "RFC2616"
+    keyStorePath: "${KEYSTORE_NAME:-example.keystore}"
+    keyStorePassword: "${KEYSTORE_PASSWORD}"
+    trustStorePath: "${KEYSTORE_NAME:-example.keystore}"
+    trustStorePassword: "${KEYSTORE_PASSWORD}"
+    supportedCipherSuites:
+    - "TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384"
+    - "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256"

--- a/punchcard-server/src/main/kotlin/com/github/ptrteixeira/punchcard/StravaPunchcardApplication.kt
+++ b/punchcard-server/src/main/kotlin/com/github/ptrteixeira/punchcard/StravaPunchcardApplication.kt
@@ -3,13 +3,29 @@ package com.github.ptrteixeira.punchcard
 import com.github.ptrteixeira.punchcard.base.BaseModule
 import com.tylerkindy.dropwizard.dagger.DaggerApplication
 import com.tylerkindy.dropwizard.dagger.DropwizardInjector
+import io.dropwizard.configuration.EnvironmentVariableSubstitutor
+import io.dropwizard.configuration.SubstitutingSourceProvider
+import io.dropwizard.setup.Bootstrap
 import io.dropwizard.setup.Environment
+import org.conscrypt.OpenSSLProvider
+import java.security.Security
 
 class StravaPunchcardApplication : DaggerApplication<StravaPunchcardConfiguration>() {
+    init {
+        Security.addProvider(OpenSSLProvider())
+    }
+
     override fun applicationInjector(configuration: StravaPunchcardConfiguration, environment: Environment): DropwizardInjector<out DaggerApplication<*>> {
         return DaggerApplicationComponent.builder()
                 .baseModule(BaseModule(configuration))
                 .build()
+    }
+
+    override fun initialize(bootstrap: Bootstrap<StravaPunchcardConfiguration>) {
+        super.initialize(bootstrap)
+
+        bootstrap.configurationSourceProvider =
+                SubstitutingSourceProvider(bootstrap.configurationSourceProvider, EnvironmentVariableSubstitutor(false))
     }
 
     companion object {

--- a/punchcard-server/src/main/kotlin/com/github/ptrteixeira/punchcard/resources/AuthResource.kt
+++ b/punchcard-server/src/main/kotlin/com/github/ptrteixeira/punchcard/resources/AuthResource.kt
@@ -8,7 +8,6 @@ import kotlinx.coroutines.reactive.awaitFirst
 import kotlinx.coroutines.runBlocking
 import org.slf4j.LoggerFactory
 import java.net.URI
-import java.util.Random
 import java.util.concurrent.TimeUnit
 import javax.inject.Inject
 import javax.inject.Named
@@ -22,6 +21,7 @@ import javax.ws.rs.core.MediaType
 import javax.ws.rs.core.NewCookie
 import javax.ws.rs.core.Response
 import javax.ws.rs.core.UriBuilder
+import kotlin.random.Random
 
 @Path("/strava")
 @Produces(MediaType.APPLICATION_JSON)
@@ -34,7 +34,6 @@ class AuthResource @Inject constructor(
     private val stravaService: IStravaService,
     registry: MeterRegistry
 ) : Resource {
-    private val random = Random()
     private val redirectUri = URI("$baseUrl/strava/callback")
     private val successfulLoginAttempts = registry.counter("http.requests.login.success")
     private val failedLoginAttempts = registry.counter("http.requests.login.failed")
@@ -42,7 +41,7 @@ class AuthResource @Inject constructor(
     @GET
     @Path("/login")
     fun authRedirect(): Response {
-        val nonce = random.nextLong().toString(16)
+        val nonce = Random.nextBytes(16).toString()
 
         val stravaAuthorizePath = UriBuilder
                 .fromPath(STRAVA_AUTHORIZE_URI)
@@ -99,7 +98,7 @@ class AuthResource @Inject constructor(
             "",
             "",
             MAX_AGE,
-            false,
+            true,
             true
     )
 

--- a/settings.gradle
+++ b/settings.gradle
@@ -7,3 +7,5 @@ include(
   'recipe-server',
   'strava-api'
 )
+
+enableFeaturePreview("IMPROVED_POM_SUPPORT")


### PR DESCRIPTION
Previously I didn't have HTTPS turned on for this application because it
is proxied behind Nginx, which *does* have HTTPS. So the connection
between a client and the server was still secured.  Still, for a variety
of reasons that didn't work great. So this gets a secured HTTP/2 server
set up, which works better for everyone.