### PR TITLE
Fix nullability checks in deserialization

### DIFF
--- a/strava-api/build.gradle.kts
+++ b/strava-api/build.gradle.kts
@@ -25,4 +25,5 @@ dependencies {
 
     testCompile("org.mockito", "mockito-core", versions["MOCKITO"])
     testCompile("io.projectreactor", "reactor-test", versions["REACTOR"])
+    testCompile("org.assertj", "assertj-core", versions["ASSERTJ"])
 }

--- a/strava-api/src/main/kotlin/models/Athlete.kt
+++ b/strava-api/src/main/kotlin/models/Athlete.kt
@@ -7,8 +7,8 @@ import com.fasterxml.jackson.databind.annotation.JsonNaming
 @JsonIgnoreProperties(ignoreUnknown = true)
 @JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy::class)
 data class Athlete(
-    val id: Long,
-    val username: String,
+    val id: Long?,
+    val username: String?,
     val firstname: String?,
     val lastname: String?,
     val city: String?,
@@ -24,5 +24,5 @@ data class Athlete(
     val resourceState: Int,
     val sex: String?,
     val state: String?,
-    val updatedAt: String
+    val updatedAt: String?
 )

--- a/strava-api/src/main/kotlin/models/TokenResponse.kt
+++ b/strava-api/src/main/kotlin/models/TokenResponse.kt
@@ -9,5 +9,6 @@ import com.fasterxml.jackson.databind.annotation.JsonNaming
 data class TokenResponse(
     val accessToken: String,
     val tokenType: String,
-    val athlete: Athlete
+    val athlete: Athlete?,
+    val state: String?
 )

--- a/strava-api/src/test/kotlin/models/TokenResponseTest.kt
+++ b/strava-api/src/test/kotlin/models/TokenResponseTest.kt
@@ -1,0 +1,55 @@
+package models
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.module.kotlin.registerKotlinModule
+import com.github.ptrteixeira.strava.api.models.TokenResponse
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+internal class TokenResponseTest {
+    private val objectMapper = ObjectMapper().registerKotlinModule()
+
+    @Test
+    fun `it can deserialize token responses with state without athlete`() {
+        val accessToken = "987654321234567898765432123456789"
+        val state = "STRAVA"
+
+        val json = """
+            {
+  "token_type": "Bearer",
+  "access_token": "$accessToken",
+  "refresh_token": "1234567898765432112345678987654321",
+  "expires_at": 1531378346,
+  "state": "$state"
+}
+        """.trimIndent()
+
+        val tokenResponse = objectMapper.readValue(json, TokenResponse::class.java)
+        assertThat(tokenResponse.athlete)
+            .isNull()
+        assertThat(tokenResponse.accessToken)
+            .isEqualTo(accessToken)
+        assertThat(tokenResponse.state)
+            .isEqualTo(state)
+    }
+
+    @Test
+    fun `it can deserialize token responses without state or athlete`() {
+        val accessToken = "987654321234567898765432123456789"
+
+        val json = """
+            {
+  "token_type": "Bearer",
+  "access_token": "$accessToken",
+  "refresh_token": "1234567898765432112345678987654321",
+  "expires_at": 1531378346
+}
+        """.trimIndent()
+
+        val tokenResponse = objectMapper.readValue(json, TokenResponse::class.java)
+        assertThat(tokenResponse.athlete)
+            .isNull()
+        assertThat(tokenResponse.accessToken)
+            .isEqualTo(accessToken)
+    }
+}

--- a/strava-api/src/test/resources/golden_token_response.json
+++ b/strava-api/src/test/resources/golden_token_response.json
@@ -1,0 +1,7 @@
+{
+  "token_type": "Bearer",
+  "access_token": "987654321234567898765432123456789",
+  "refresh_token": "1234567898765432112345678987654321",
+  "expires_at": 1531378346,
+  "state": "STRAVA"
+}


### PR DESCRIPTION
I *think* that Strava was giving me partially empty objects, that I couldn't deserialize because of null-checks on the object I deserializing it into. I can't really tell because for reasons I'm *also* not sure about, error reporting isn't firing. So I'm in a bit of a bind.