### PR TITLE
Bulk rename files

### DIFF
--- a/mvb/BUILD
+++ b/mvb/BUILD
@@ -1,0 +1,15 @@
+package(default_visibility = ["//visibility:public"])
+
+load("@io_bazel_rules_rust//rust:rust.bzl", "rust_binary", "rust_library", "rust_test")
+
+rust_binary(
+    name = "mvb",
+    srcs = [
+        "src/main.rs",
+    ],
+    deps = [
+        "//third-party/cargo:clap",
+        "//third-party/cargo:regex",
+        "//third-party/cargo:walkdir",
+    ],
+)

--- a/mvb/src/main.rs
+++ b/mvb/src/main.rs
@@ -1,0 +1,47 @@
+extern crate clap;
+extern crate regex;
+extern crate walkdir;
+
+use clap::{Arg, App};
+use regex::Regex;
+use std::fs;
+use std::borrow::Borrow;
+use std::path::Path;
+use walkdir::{ DirEntry, WalkDir };
+
+fn main() {
+  let matches = App::new("mvb")
+      .version("0.1.0")
+      .author("Peter Teixeira")
+      .about("Bulk renames files")
+      .arg(Arg::with_name("from_pattern").required(true).index(1))
+      .arg(Arg::with_name("to_pattern").required(true).index(2))
+      .get_matches();
+
+  let from_pattern = matches.value_of("from_pattern").unwrap();
+  let to_pattern = matches.value_of("to_pattern").unwrap();
+  let re = Regex::new(from_pattern)
+      .expect("Could not parse input pattern");
+
+  for entry in WalkDir::new(".").into_iter().filter_map(|e| e.ok()) {
+      try_move_file(entry, &to_pattern, &re);
+  }
+}
+
+fn try_move_file(entry: DirEntry, target_pattern: &str, re: &Regex) -> Option<()> {
+  let filename = entry.file_name().to_str()?;
+  
+  if !re.is_match(filename) {
+      return None;
+  }
+
+  let replaced_name = re.replace(filename, target_pattern);
+  let target_file_name: &str = replaced_name.borrow();
+  let target_file_path = Path::new(target_file_name);
+
+  println!("Renaming {} to {:?}", entry.path().display(), target_file_name);
+  return match fs::rename(entry.path(), target_file_path) {
+      Ok(_) => None,
+      Err(e) => panic!(e),
+  }
+}

--- a/third-party/cargo/BUILD
+++ b/third-party/cargo/BUILD
@@ -20,3 +20,11 @@ alias(
     name = "pest_derive",
     actual = "@raze__pest_derive__2_1_0//:pest_derive",
 )
+alias(
+    name = "regex",
+    actual = "@raze__regex__1_1_2//:regex",
+)
+alias(
+    name = "walkdir",
+    actual = "@raze__walkdir__2_2_7//:walkdir",
+)

--- a/third-party/cargo/Cargo.lock
+++ b/third-party/cargo/Cargo.lock
@@ -1,4 +1,12 @@
 [[package]]
+name = "aho-corasick"
+version = "0.6.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "memchr 2.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "ansi_term"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -61,6 +69,8 @@ dependencies = [
  "clap 2.32.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "pest 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "pest_derive 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex 1.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "walkdir 2.2.7 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -85,6 +95,11 @@ dependencies = [
 ]
 
 [[package]]
+name = "lazy_static"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "libc"
 version = "0.2.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -92,6 +107,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 [[package]]
 name = "maplit"
 version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "memchr"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -163,6 +183,34 @@ dependencies = [
 ]
 
 [[package]]
+name = "regex"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "aho-corasick 0.6.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "memchr 2.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex-syntax 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "thread_local 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "utf8-ranges 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "ucd-util 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "same-file"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "winapi-util 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "sha-1"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -207,6 +255,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "thread_local"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "typenum"
 version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -214,6 +270,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 [[package]]
 name = "ucd-trie"
 version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "ucd-util"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -227,9 +288,24 @@ version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "utf8-ranges"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "vec_map"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "walkdir"
+version = "2.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "same-file 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi-util 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "winapi"
@@ -246,11 +322,20 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "winapi-util"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "winapi 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [metadata]
+"checksum aho-corasick 0.6.10 (registry+https://github.com/rust-lang/crates.io-index)" = "81ce3d38065e618af2d7b77e10c5ad9a069859b4be3c2250f674af3840d9c8a5"
 "checksum ansi_term 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ee49baf6cb617b853aa8d93bf420db2383fab46d314482ca2803b40d5fde979b"
 "checksum arrayref 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)" = "0d382e583f07208808f6b1249e60848879ba3543f57c32277bf52d69c2f0f0ee"
 "checksum atty 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)" = "9a7d5b8723950951411ee34d271d99dddcc2035a16ab25310ea2c8cfd4369652"
@@ -261,8 +346,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum digest 0.7.6 (registry+https://github.com/rust-lang/crates.io-index)" = "03b072242a8cbaf9c145665af9d250c59af3b958f83ed6824e13533cf76d5b90"
 "checksum fake-simd 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "e88a8acf291dafb59c2d96e8f59828f3838bb1a70398823ade51a84de6a6deed"
 "checksum generic-array 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ef25c5683767570c2bbd7deba372926a55eaae9982d7726ee2a1050239d45b9d"
+"checksum lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "bc5729f27f159ddd61f4df6228e827e86643d4d3e7c32183cb30a1c08f604a14"
 "checksum libc 0.2.50 (registry+https://github.com/rust-lang/crates.io-index)" = "aab692d7759f5cd8c859e169db98ae5b52c924add2af5fbbca11d12fefb567c1"
 "checksum maplit 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "08cbb6b4fef96b6d77bfc40ec491b1690c779e77b05cd9f07f787ed376fd4c43"
+"checksum memchr 2.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "2efc7bc57c883d4a4d6e3246905283d8dae951bb3bd32f49d6ef297f546e1c39"
 "checksum pest 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "54f0c72a98d8ab3c99560bfd16df8059cc10e1f9a8e83e6e3b97718dd766e9c3"
 "checksum pest_derive 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "833d1ae558dc601e9a60366421196a8d94bc0ac980476d0b67e1d0988d72b2d0"
 "checksum pest_generator 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "63120576c4efd69615b5537d3d052257328a4ca82876771d6944424ccfd9f646"
@@ -271,16 +358,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum quote 0.6.11 (registry+https://github.com/rust-lang/crates.io-index)" = "cdd8e04bd9c52e0342b406469d494fcb033be4bdbe5c606016defbb1681411e1"
 "checksum redox_syscall 0.1.51 (registry+https://github.com/rust-lang/crates.io-index)" = "423e376fffca3dfa06c9e9790a9ccd282fafb3cc6e6397d01dbf64f9bacc6b85"
 "checksum redox_termios 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "7e891cfe48e9100a70a3b6eb652fef28920c117d366339687bd5576160db0f76"
+"checksum regex 1.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "53ee8cfdddb2e0291adfb9f13d31d3bbe0a03c9a402c01b1e24188d86c35b24f"
+"checksum regex-syntax 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)" = "8c2f35eedad5295fdf00a63d7d4b238135723f92b434ec06774dad15c7ab0861"
+"checksum same-file 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)" = "8f20c4be53a8a1ff4c1f1b2bd14570d2f634628709752f0702ecdd2b3f9a5267"
 "checksum sha-1 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "51b9d1f3b5de8a167ab06834a7c883bd197f2191e1dda1a22d9ccfeedbf9aded"
 "checksum strsim 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "bb4f380125926a99e52bc279241539c018323fab05ad6368b56f93d9369ff550"
 "checksum syn 0.15.29 (registry+https://github.com/rust-lang/crates.io-index)" = "1825685f977249735d510a242a6727b46efe914bb67e38d30c071b1b72b1d5c2"
 "checksum termion 1.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "689a3bdfaab439fd92bc87df5c4c78417d3cbe537487274e9b0b2dce76e92096"
 "checksum textwrap 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)" = "307686869c93e71f94da64286f9a9524c0f308a9e1c87a583de8e9c9039ad3f6"
+"checksum thread_local 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)" = "c6b53e329000edc2b34dbe8545fd20e55a333362d0a321909685a19bd28c3f1b"
 "checksum typenum 1.10.0 (registry+https://github.com/rust-lang/crates.io-index)" = "612d636f949607bdf9b123b4a6f6d966dedf3ff669f7f045890d3a4a73948169"
 "checksum ucd-trie 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "71a9c5b1fe77426cf144cc30e49e955270f5086e31a6441dfa8b32efc09b9d77"
+"checksum ucd-util 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "535c204ee4d8434478593480b8f86ab45ec9aae0e83c568ca81abf0fd0e88f86"
 "checksum unicode-width 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "882386231c45df4700b275c7ff55b6f3698780a650026380e72dabe76fa46526"
 "checksum unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "fc72304796d0818e357ead4e000d19c9c174ab23dc11093ac919054d20a6a7fc"
+"checksum utf8-ranges 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "796f7e48bef87609f7ade7e06495a87d5cd06c7866e6a5cbfceffc558a243737"
 "checksum vec_map 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)" = "05c78687fb1a80548ae3250346c3db86a80a7cdd77bda190189f2d0a0987c81a"
+"checksum walkdir 2.2.7 (registry+https://github.com/rust-lang/crates.io-index)" = "9d9d7ed3431229a144296213105a390676cc49c9b6a72bd19f3176c98e129fa1"
 "checksum winapi 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)" = "92c1eb33641e276cfa214a0522acad57be5c56b10cb348b3c5117db75f3ac4b0"
 "checksum winapi-i686-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+"checksum winapi-util 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7168bab6e1daee33b4557efd0e95d5ca70a03706d39fa5f3fe7a236f584b03c9"
 "checksum winapi-x86_64-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"

--- a/third-party/cargo/Cargo.toml
+++ b/third-party/cargo/Cargo.toml
@@ -6,9 +6,11 @@ version = "0.0.0"
 path = "fake_lib.rs"
 
 [dependencies]
+clap = "2"
 pest = "2"
 pest_derive = "2"
-clap = "2"
+regex = "1"
+walkdir = "2"
 
 [raze]
 genmode = "Remote"

--- a/third-party/cargo/crates.bzl
+++ b/third-party/cargo/crates.bzl
@@ -17,6 +17,15 @@ def _new_git_repository(name, **kwargs):
 def raze_fetch_remote_crates():
 
     _new_http_archive(
+        name = "raze__aho_corasick__0_6_10",
+        url = "https://crates-io.s3-us-west-1.amazonaws.com/crates/aho-corasick/aho-corasick-0.6.10.crate",
+        type = "tar.gz",
+        sha256 = "81ce3d38065e618af2d7b77e10c5ad9a069859b4be3c2250f674af3840d9c8a5",
+        strip_prefix = "aho-corasick-0.6.10",
+        build_file = Label("//third-party/cargo/remote:aho-corasick-0.6.10.BUILD")
+    )
+
+    _new_http_archive(
         name = "raze__ansi_term__0_11_0",
         url = "https://crates-io.s3-us-west-1.amazonaws.com/crates/ansi_term/ansi_term-0.11.0.crate",
         type = "tar.gz",
@@ -107,6 +116,15 @@ def raze_fetch_remote_crates():
     )
 
     _new_http_archive(
+        name = "raze__lazy_static__1_3_0",
+        url = "https://crates-io.s3-us-west-1.amazonaws.com/crates/lazy_static/lazy_static-1.3.0.crate",
+        type = "tar.gz",
+        sha256 = "bc5729f27f159ddd61f4df6228e827e86643d4d3e7c32183cb30a1c08f604a14",
+        strip_prefix = "lazy_static-1.3.0",
+        build_file = Label("//third-party/cargo/remote:lazy_static-1.3.0.BUILD")
+    )
+
+    _new_http_archive(
         name = "raze__libc__0_2_50",
         url = "https://crates-io.s3-us-west-1.amazonaws.com/crates/libc/libc-0.2.50.crate",
         type = "tar.gz",
@@ -122,6 +140,15 @@ def raze_fetch_remote_crates():
         sha256 = "08cbb6b4fef96b6d77bfc40ec491b1690c779e77b05cd9f07f787ed376fd4c43",
         strip_prefix = "maplit-1.0.1",
         build_file = Label("//third-party/cargo/remote:maplit-1.0.1.BUILD")
+    )
+
+    _new_http_archive(
+        name = "raze__memchr__2_2_0",
+        url = "https://crates-io.s3-us-west-1.amazonaws.com/crates/memchr/memchr-2.2.0.crate",
+        type = "tar.gz",
+        sha256 = "2efc7bc57c883d4a4d6e3246905283d8dae951bb3bd32f49d6ef297f546e1c39",
+        strip_prefix = "memchr-2.2.0",
+        build_file = Label("//third-party/cargo/remote:memchr-2.2.0.BUILD")
     )
 
     _new_http_archive(
@@ -197,6 +224,33 @@ def raze_fetch_remote_crates():
     )
 
     _new_http_archive(
+        name = "raze__regex__1_1_2",
+        url = "https://crates-io.s3-us-west-1.amazonaws.com/crates/regex/regex-1.1.2.crate",
+        type = "tar.gz",
+        sha256 = "53ee8cfdddb2e0291adfb9f13d31d3bbe0a03c9a402c01b1e24188d86c35b24f",
+        strip_prefix = "regex-1.1.2",
+        build_file = Label("//third-party/cargo/remote:regex-1.1.2.BUILD")
+    )
+
+    _new_http_archive(
+        name = "raze__regex_syntax__0_6_5",
+        url = "https://crates-io.s3-us-west-1.amazonaws.com/crates/regex-syntax/regex-syntax-0.6.5.crate",
+        type = "tar.gz",
+        sha256 = "8c2f35eedad5295fdf00a63d7d4b238135723f92b434ec06774dad15c7ab0861",
+        strip_prefix = "regex-syntax-0.6.5",
+        build_file = Label("//third-party/cargo/remote:regex-syntax-0.6.5.BUILD")
+    )
+
+    _new_http_archive(
+        name = "raze__same_file__1_0_4",
+        url = "https://crates-io.s3-us-west-1.amazonaws.com/crates/same-file/same-file-1.0.4.crate",
+        type = "tar.gz",
+        sha256 = "8f20c4be53a8a1ff4c1f1b2bd14570d2f634628709752f0702ecdd2b3f9a5267",
+        strip_prefix = "same-file-1.0.4",
+        build_file = Label("//third-party/cargo/remote:same-file-1.0.4.BUILD")
+    )
+
+    _new_http_archive(
         name = "raze__sha_1__0_7_0",
         url = "https://crates-io.s3-us-west-1.amazonaws.com/crates/sha-1/sha-1-0.7.0.crate",
         type = "tar.gz",
@@ -242,6 +296,15 @@ def raze_fetch_remote_crates():
     )
 
     _new_http_archive(
+        name = "raze__thread_local__0_3_6",
+        url = "https://crates-io.s3-us-west-1.amazonaws.com/crates/thread_local/thread_local-0.3.6.crate",
+        type = "tar.gz",
+        sha256 = "c6b53e329000edc2b34dbe8545fd20e55a333362d0a321909685a19bd28c3f1b",
+        strip_prefix = "thread_local-0.3.6",
+        build_file = Label("//third-party/cargo/remote:thread_local-0.3.6.BUILD")
+    )
+
+    _new_http_archive(
         name = "raze__typenum__1_10_0",
         url = "https://crates-io.s3-us-west-1.amazonaws.com/crates/typenum/typenum-1.10.0.crate",
         type = "tar.gz",
@@ -257,6 +320,15 @@ def raze_fetch_remote_crates():
         sha256 = "71a9c5b1fe77426cf144cc30e49e955270f5086e31a6441dfa8b32efc09b9d77",
         strip_prefix = "ucd-trie-0.1.1",
         build_file = Label("//third-party/cargo/remote:ucd-trie-0.1.1.BUILD")
+    )
+
+    _new_http_archive(
+        name = "raze__ucd_util__0_1_3",
+        url = "https://crates-io.s3-us-west-1.amazonaws.com/crates/ucd-util/ucd-util-0.1.3.crate",
+        type = "tar.gz",
+        sha256 = "535c204ee4d8434478593480b8f86ab45ec9aae0e83c568ca81abf0fd0e88f86",
+        strip_prefix = "ucd-util-0.1.3",
+        build_file = Label("//third-party/cargo/remote:ucd-util-0.1.3.BUILD")
     )
 
     _new_http_archive(
@@ -278,12 +350,30 @@ def raze_fetch_remote_crates():
     )
 
     _new_http_archive(
+        name = "raze__utf8_ranges__1_0_2",
+        url = "https://crates-io.s3-us-west-1.amazonaws.com/crates/utf8-ranges/utf8-ranges-1.0.2.crate",
+        type = "tar.gz",
+        sha256 = "796f7e48bef87609f7ade7e06495a87d5cd06c7866e6a5cbfceffc558a243737",
+        strip_prefix = "utf8-ranges-1.0.2",
+        build_file = Label("//third-party/cargo/remote:utf8-ranges-1.0.2.BUILD")
+    )
+
+    _new_http_archive(
         name = "raze__vec_map__0_8_1",
         url = "https://crates-io.s3-us-west-1.amazonaws.com/crates/vec_map/vec_map-0.8.1.crate",
         type = "tar.gz",
         sha256 = "05c78687fb1a80548ae3250346c3db86a80a7cdd77bda190189f2d0a0987c81a",
         strip_prefix = "vec_map-0.8.1",
         build_file = Label("//third-party/cargo/remote:vec_map-0.8.1.BUILD")
+    )
+
+    _new_http_archive(
+        name = "raze__walkdir__2_2_7",
+        url = "https://crates-io.s3-us-west-1.amazonaws.com/crates/walkdir/walkdir-2.2.7.crate",
+        type = "tar.gz",
+        sha256 = "9d9d7ed3431229a144296213105a390676cc49c9b6a72bd19f3176c98e129fa1",
+        strip_prefix = "walkdir-2.2.7",
+        build_file = Label("//third-party/cargo/remote:walkdir-2.2.7.BUILD")
     )
 
     _new_http_archive(
@@ -302,6 +392,15 @@ def raze_fetch_remote_crates():
         sha256 = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6",
         strip_prefix = "winapi-i686-pc-windows-gnu-0.4.0",
         build_file = Label("//third-party/cargo/remote:winapi-i686-pc-windows-gnu-0.4.0.BUILD")
+    )
+
+    _new_http_archive(
+        name = "raze__winapi_util__0_1_2",
+        url = "https://crates-io.s3-us-west-1.amazonaws.com/crates/winapi-util/winapi-util-0.1.2.crate",
+        type = "tar.gz",
+        sha256 = "7168bab6e1daee33b4557efd0e95d5ca70a03706d39fa5f3fe7a236f584b03c9",
+        strip_prefix = "winapi-util-0.1.2",
+        build_file = Label("//third-party/cargo/remote:winapi-util-0.1.2.BUILD")
     )
 
     _new_http_archive(

--- a/third-party/cargo/remote/aho-corasick-0.6.10.BUILD
+++ b/third-party/cargo/remote/aho-corasick-0.6.10.BUILD
@@ -1,0 +1,66 @@
+"""
+cargo-raze crate build file.
+
+DO NOT EDIT! Replaced on runs of cargo-raze
+"""
+package(default_visibility = [
+  # Public for visibility by "@raze__crate__version//" targets.
+  #
+  # Prefer access through "//third-party/cargo", which limits external
+  # visibility to explicit Cargo.toml dependencies.
+  "//visibility:public",
+])
+
+licenses([
+  "notice", # "MIT"
+  "unencumbered", # "Unlicense"
+])
+
+load(
+    "@io_bazel_rules_rust//rust:rust.bzl",
+    "rust_library",
+    "rust_binary",
+    "rust_test",
+)
+
+
+rust_binary(
+    # Prefix bin name to disambiguate from (probable) collision with lib name
+    # N.B.: The exact form of this is subject to change.
+    name = "cargo_bin_aho_corasick_dot",
+    crate_root = "src/main.rs",
+    edition = "2015",
+    srcs = glob(["**/*.rs"]),
+    deps = [
+        # Binaries get an implicit dependency on their lib
+        ":aho_corasick",
+        "@raze__memchr__2_2_0//:memchr",
+    ],
+    rustc_flags = [
+        "--cap-lints=allow",
+    ],
+    version = "0.6.10",
+    crate_features = [
+    ],
+)
+
+
+rust_library(
+    name = "aho_corasick",
+    crate_root = "src/lib.rs",
+    crate_type = "lib",
+    edition = "2015",
+    srcs = glob(["**/*.rs"]),
+    deps = [
+        "@raze__memchr__2_2_0//:memchr",
+    ],
+    rustc_flags = [
+        "--cap-lints=allow",
+    ],
+    version = "0.6.10",
+    crate_features = [
+    ],
+)
+
+# Unsupported target "bench" with type "bench" omitted
+# Unsupported target "dict-search" with type "example" omitted

--- a/third-party/cargo/remote/lazy_static-1.3.0.BUILD
+++ b/third-party/cargo/remote/lazy_static-1.3.0.BUILD
@@ -23,10 +23,9 @@ load(
 )
 
 
-# Unsupported target "build-script-build" with type "custom-build" omitted
 
 rust_library(
-    name = "winapi",
+    name = "lazy_static",
     crate_root = "src/lib.rs",
     crate_type = "lib",
     edition = "2015",
@@ -36,19 +35,10 @@ rust_library(
     rustc_flags = [
         "--cap-lints=allow",
     ],
-    version = "0.3.6",
+    version = "1.3.0",
     crate_features = [
-        "consoleapi",
-        "errhandlingapi",
-        "fileapi",
-        "minwinbase",
-        "minwindef",
-        "processenv",
-        "std",
-        "winbase",
-        "wincon",
-        "winerror",
-        "winnt",
     ],
 )
 
+# Unsupported target "no_std" with type "test" omitted
+# Unsupported target "test" with type "test" omitted

--- a/third-party/cargo/remote/memchr-2.2.0.BUILD
+++ b/third-party/cargo/remote/memchr-2.2.0.BUILD
@@ -12,7 +12,8 @@ package(default_visibility = [
 ])
 
 licenses([
-  "notice", # "MIT,Apache-2.0"
+  "notice", # "MIT"
+  "unencumbered", # "Unlicense"
 ])
 
 load(
@@ -26,7 +27,7 @@ load(
 # Unsupported target "build-script-build" with type "custom-build" omitted
 
 rust_library(
-    name = "winapi",
+    name = "memchr",
     crate_root = "src/lib.rs",
     crate_type = "lib",
     edition = "2015",
@@ -36,19 +37,10 @@ rust_library(
     rustc_flags = [
         "--cap-lints=allow",
     ],
-    version = "0.3.6",
+    version = "2.2.0",
     crate_features = [
-        "consoleapi",
-        "errhandlingapi",
-        "fileapi",
-        "minwinbase",
-        "minwindef",
-        "processenv",
-        "std",
-        "winbase",
-        "wincon",
-        "winerror",
-        "winnt",
+        "default",
+        "use_std",
     ],
 )
 

--- a/third-party/cargo/remote/regex-1.1.2.BUILD
+++ b/third-party/cargo/remote/regex-1.1.2.BUILD
@@ -1,0 +1,65 @@
+"""
+cargo-raze crate build file.
+
+DO NOT EDIT! Replaced on runs of cargo-raze
+"""
+package(default_visibility = [
+  # Public for visibility by "@raze__crate__version//" targets.
+  #
+  # Prefer access through "//third-party/cargo", which limits external
+  # visibility to explicit Cargo.toml dependencies.
+  "//visibility:public",
+])
+
+licenses([
+  "notice", # "MIT,Apache-2.0"
+])
+
+load(
+    "@io_bazel_rules_rust//rust:rust.bzl",
+    "rust_library",
+    "rust_binary",
+    "rust_test",
+)
+
+
+# Unsupported target "backtrack" with type "test" omitted
+# Unsupported target "backtrack-bytes" with type "test" omitted
+# Unsupported target "backtrack-utf8bytes" with type "test" omitted
+# Unsupported target "build-script-build" with type "custom-build" omitted
+# Unsupported target "crates-regex" with type "test" omitted
+# Unsupported target "default" with type "test" omitted
+# Unsupported target "default-bytes" with type "test" omitted
+# Unsupported target "nfa" with type "test" omitted
+# Unsupported target "nfa-bytes" with type "test" omitted
+# Unsupported target "nfa-utf8bytes" with type "test" omitted
+
+rust_library(
+    name = "regex",
+    crate_root = "src/lib.rs",
+    crate_type = "lib",
+    edition = "2015",
+    srcs = glob(["**/*.rs"]),
+    deps = [
+        "@raze__aho_corasick__0_6_10//:aho_corasick",
+        "@raze__memchr__2_2_0//:memchr",
+        "@raze__regex_syntax__0_6_5//:regex_syntax",
+        "@raze__thread_local__0_3_6//:thread_local",
+        "@raze__utf8_ranges__1_0_2//:utf8_ranges",
+    ],
+    rustc_flags = [
+        "--cap-lints=allow",
+    ],
+    version = "1.1.2",
+    crate_features = [
+        "default",
+        "use_std",
+    ],
+)
+
+# Unsupported target "shootout-regex-dna" with type "example" omitted
+# Unsupported target "shootout-regex-dna-bytes" with type "example" omitted
+# Unsupported target "shootout-regex-dna-cheat" with type "example" omitted
+# Unsupported target "shootout-regex-dna-replace" with type "example" omitted
+# Unsupported target "shootout-regex-dna-single" with type "example" omitted
+# Unsupported target "shootout-regex-dna-single-cheat" with type "example" omitted

--- a/third-party/cargo/remote/regex-syntax-0.6.5.BUILD
+++ b/third-party/cargo/remote/regex-syntax-0.6.5.BUILD
@@ -23,32 +23,22 @@ load(
 )
 
 
-# Unsupported target "build-script-build" with type "custom-build" omitted
+# Unsupported target "bench" with type "bench" omitted
 
 rust_library(
-    name = "winapi",
+    name = "regex_syntax",
     crate_root = "src/lib.rs",
     crate_type = "lib",
     edition = "2015",
     srcs = glob(["**/*.rs"]),
     deps = [
+        "@raze__ucd_util__0_1_3//:ucd_util",
     ],
     rustc_flags = [
         "--cap-lints=allow",
     ],
-    version = "0.3.6",
+    version = "0.6.5",
     crate_features = [
-        "consoleapi",
-        "errhandlingapi",
-        "fileapi",
-        "minwinbase",
-        "minwindef",
-        "processenv",
-        "std",
-        "winbase",
-        "wincon",
-        "winerror",
-        "winnt",
     ],
 )
 

--- a/third-party/cargo/remote/same-file-1.0.4.BUILD
+++ b/third-party/cargo/remote/same-file-1.0.4.BUILD
@@ -12,7 +12,8 @@ package(default_visibility = [
 ])
 
 licenses([
-  "notice", # "MIT,Apache-2.0"
+  "notice", # "MIT"
+  "unencumbered", # "Unlicense"
 ])
 
 load(
@@ -23,10 +24,11 @@ load(
 )
 
 
-# Unsupported target "build-script-build" with type "custom-build" omitted
+# Unsupported target "is_same_file" with type "example" omitted
+# Unsupported target "is_stderr" with type "example" omitted
 
 rust_library(
-    name = "winapi",
+    name = "same_file",
     crate_root = "src/lib.rs",
     crate_type = "lib",
     edition = "2015",
@@ -36,19 +38,8 @@ rust_library(
     rustc_flags = [
         "--cap-lints=allow",
     ],
-    version = "0.3.6",
+    version = "1.0.4",
     crate_features = [
-        "consoleapi",
-        "errhandlingapi",
-        "fileapi",
-        "minwinbase",
-        "minwindef",
-        "processenv",
-        "std",
-        "winbase",
-        "wincon",
-        "winerror",
-        "winnt",
     ],
 )
 

--- a/third-party/cargo/remote/thread_local-0.3.6.BUILD
+++ b/third-party/cargo/remote/thread_local-0.3.6.BUILD
@@ -12,7 +12,7 @@ package(default_visibility = [
 ])
 
 licenses([
-  "notice", # "MIT,Apache-2.0"
+  "notice", # "Apache-2.0,MIT"
 ])
 
 load(
@@ -23,32 +23,22 @@ load(
 )
 
 
-# Unsupported target "build-script-build" with type "custom-build" omitted
+# Unsupported target "thread_local" with type "bench" omitted
 
 rust_library(
-    name = "winapi",
+    name = "thread_local",
     crate_root = "src/lib.rs",
     crate_type = "lib",
     edition = "2015",
     srcs = glob(["**/*.rs"]),
     deps = [
+        "@raze__lazy_static__1_3_0//:lazy_static",
     ],
     rustc_flags = [
         "--cap-lints=allow",
     ],
     version = "0.3.6",
     crate_features = [
-        "consoleapi",
-        "errhandlingapi",
-        "fileapi",
-        "minwinbase",
-        "minwindef",
-        "processenv",
-        "std",
-        "winbase",
-        "wincon",
-        "winerror",
-        "winnt",
     ],
 )
 

--- a/third-party/cargo/remote/ucd-util-0.1.3.BUILD
+++ b/third-party/cargo/remote/ucd-util-0.1.3.BUILD
@@ -23,10 +23,9 @@ load(
 )
 
 
-# Unsupported target "build-script-build" with type "custom-build" omitted
 
 rust_library(
-    name = "winapi",
+    name = "ucd_util",
     crate_root = "src/lib.rs",
     crate_type = "lib",
     edition = "2015",
@@ -36,19 +35,8 @@ rust_library(
     rustc_flags = [
         "--cap-lints=allow",
     ],
-    version = "0.3.6",
+    version = "0.1.3",
     crate_features = [
-        "consoleapi",
-        "errhandlingapi",
-        "fileapi",
-        "minwinbase",
-        "minwindef",
-        "processenv",
-        "std",
-        "winbase",
-        "wincon",
-        "winerror",
-        "winnt",
     ],
 )
 

--- a/third-party/cargo/remote/utf8-ranges-1.0.2.BUILD
+++ b/third-party/cargo/remote/utf8-ranges-1.0.2.BUILD
@@ -12,7 +12,8 @@ package(default_visibility = [
 ])
 
 licenses([
-  "notice", # "MIT,Apache-2.0"
+  "notice", # "MIT"
+  "unencumbered", # "Unlicense"
 ])
 
 load(
@@ -23,10 +24,10 @@ load(
 )
 
 
-# Unsupported target "build-script-build" with type "custom-build" omitted
+# Unsupported target "bench" with type "bench" omitted
 
 rust_library(
-    name = "winapi",
+    name = "utf8_ranges",
     crate_root = "src/lib.rs",
     crate_type = "lib",
     edition = "2015",
@@ -36,19 +37,8 @@ rust_library(
     rustc_flags = [
         "--cap-lints=allow",
     ],
-    version = "0.3.6",
+    version = "1.0.2",
     crate_features = [
-        "consoleapi",
-        "errhandlingapi",
-        "fileapi",
-        "minwinbase",
-        "minwindef",
-        "processenv",
-        "std",
-        "winbase",
-        "wincon",
-        "winerror",
-        "winnt",
     ],
 )
 

--- a/third-party/cargo/remote/walkdir-2.2.7.BUILD
+++ b/third-party/cargo/remote/walkdir-2.2.7.BUILD
@@ -12,7 +12,8 @@ package(default_visibility = [
 ])
 
 licenses([
-  "notice", # "MIT,Apache-2.0"
+  "notice", # "MIT"
+  "unencumbered", # "Unlicense"
 ])
 
 load(
@@ -23,32 +24,22 @@ load(
 )
 
 
-# Unsupported target "build-script-build" with type "custom-build" omitted
+# Unsupported target "walkdir" with type "example" omitted
 
 rust_library(
-    name = "winapi",
+    name = "walkdir",
     crate_root = "src/lib.rs",
     crate_type = "lib",
     edition = "2015",
     srcs = glob(["**/*.rs"]),
     deps = [
+        "@raze__same_file__1_0_4//:same_file",
     ],
     rustc_flags = [
         "--cap-lints=allow",
     ],
-    version = "0.3.6",
+    version = "2.2.7",
     crate_features = [
-        "consoleapi",
-        "errhandlingapi",
-        "fileapi",
-        "minwinbase",
-        "minwindef",
-        "processenv",
-        "std",
-        "winbase",
-        "wincon",
-        "winerror",
-        "winnt",
     ],
 )
 

--- a/third-party/cargo/remote/winapi-util-0.1.2.BUILD
+++ b/third-party/cargo/remote/winapi-util-0.1.2.BUILD
@@ -12,7 +12,8 @@ package(default_visibility = [
 ])
 
 licenses([
-  "notice", # "MIT,Apache-2.0"
+  "notice", # "MIT"
+  "unencumbered", # "Unlicense"
 ])
 
 load(
@@ -23,10 +24,9 @@ load(
 )
 
 
-# Unsupported target "build-script-build" with type "custom-build" omitted
 
 rust_library(
-    name = "winapi",
+    name = "winapi_util",
     crate_root = "src/lib.rs",
     crate_type = "lib",
     edition = "2015",
@@ -36,19 +36,8 @@ rust_library(
     rustc_flags = [
         "--cap-lints=allow",
     ],
-    version = "0.3.6",
+    version = "0.1.2",
     crate_features = [
-        "consoleapi",
-        "errhandlingapi",
-        "fileapi",
-        "minwinbase",
-        "minwindef",
-        "processenv",
-        "std",
-        "winbase",
-        "wincon",
-        "winerror",
-        "winnt",
     ],
 )
 


### PR DESCRIPTION
Recently ran into a circumstance where I needed to do some bulk file renaming, and didn't 
have a good utility to do it. So I hammered something out as quickly as possible, for when I need to do this 
again next week. 

In short, this isn't great at the moment, but it works, technically. Probably would have been easier to write it in Python (or Go or, heck, Bash), but I kinda like Rust and it's not *that* bad for hammering something out if you don't really care about doing things well.

Anyways, syntax: `mvb '(.*)\.taipan' '$1.egg'`