### PR TITLE
Start building resume with Bazel

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -12,6 +12,13 @@ http_archive(
 )
 
 http_archive(
+   name = "bazel_latex",
+   strip_prefix = "bazel-latex-0.17",
+   sha256 = "66ca4240628a4e40cc02d7f77f06b93269dad0068e7a844009fd439e5c55f5a9",
+   url = "https://github.com/ProdriveTechnologies/bazel-latex/archive/v0.17.tar.gz",
+)
+
+http_archive(
     name = "io_bazel_rules_rust",
     sha256 = "69757af5bbb75a485775301d9e4b724f17a54eb9adc27e69adfefead6ef3ce07",
     strip_prefix = "rules_rust-761ef8f820a96c87a288b4f499b7f61772733f32",
@@ -19,6 +26,9 @@ http_archive(
         "https://github.com/bazelbuild/rules_rust/archive/761ef8f820a96c87a288b4f499b7f61772733f32.tar.gz",
     ],
 )
+
+load("@bazel_latex//:repositories.bzl", "latex_repositories")
+latex_repositories()
 
 load("@io_bazel_rules_rust//rust:repositories.bzl", "rust_repositories")
 

--- a/resume/BUILD
+++ b/resume/BUILD
@@ -1,0 +1,11 @@
+load("@bazel_latex//:latex.bzl", "latex_document")
+
+latex_document(
+  name = "resume",
+  srcs = [
+    "@bazel_latex//packages:array",
+    "@bazel_latex//packages:enumitem",
+    "@bazel_latex//packages:geometry",
+  ],
+  main = "resume.ltx",
+)

--- a/resume/resume.ltx
+++ b/resume/resume.ltx
@@ -1,0 +1,113 @@
+\documentclass{article}
+
+\usepackage[margin=0.75in]{geometry}
+\usepackage{array}
+\usepackage{enumitem}
+
+\setlength{\parindent}{0pt}
+\let\olditemize\itemize
+\setlist[itemize]{noitemsep,topsep=0pt}
+
+\newcommand{\secline}{\vspace{2mm}\rule{\linewidth}{.4pt}\vspace{1mm}}
+\newcommand{\emphline}{\begin{center}\line(1,0){250}\end{center}}
+\newcommand{\shortline}{\line(1, 0){250}\\}
+
+\newcommand{\hname}[1]{\textbf{{\LARGE #1}}}
+\newcommand{\hmain}[1]{\vspace{4mm}\textbf{{\large #1}}\vspace{1mm}\hrule\vspace{1mm}}
+\newcommand{\hsub}[1]{\vspace{1mm}\textbf{#1}}
+
+
+\begin{document}
+\thispagestyle{empty}
+\begin{center}
+\hname{Peter Teixeira} \\
+teixeira.p@husky.neu.edu \S{} (774) 641-4648 \\
+linkedin.com/in/PtrTeixeira \S{} github.com/PtrTeixeira \\
+Available: January - July 2018
+\end{center}
+
+\hsub{Local Address:} \hfill \hsub{Permanent Address:} \\
+50 Leon Street        \hfill 30 Oakridge Road \\
+Box 3166              \hfill Holden, MA 01520 \\
+Boston, MA 02115
+
+
+\hmain{Education}
+\hsub{Northeastern University}, Boston, MA \hfill 2014 - Present \\
+\emph{College of Computer and Information Science} \\
+Candidate for a Bachelor of Science in Computer Science and Mathematics, 2019 \\
+\textbf{GPA: 3.90/4.00}
+
+\begin{tabular}{p{5cm}p{12cm}}
+Related Coursework: &
+        Statistics and Stochastic Processes, Object-Oriented Design,
+        Software Development\\
+Activities: & Habitat for Humanity, Club Running
+\end{tabular}
+
+\hmain{Computer Knowledge}
+\begin{tabular}{p{5cm}p{12cm}}
+Languages: & Java, Javascript,  Kotlin \\
+Technologies: & React, Redux, JDBI \\
+\end{tabular}
+
+
+\hmain{Projects}
+\begin{tabular}{p{5cm}p{12cm}}
+NUSports: & A Java web scraper and GUI to collect and display information on
+Northeastern's standing in the CAA \\
+Underload & An interpreter for the Underload esoteric programming language,
+implemented in Racket
+\end{tabular}
+
+\hmain{Work Experience}
+\hsub{HubSpot} \hfill Jan. 2017 - July 2017 \\
+Product Co-Op
+\begin{itemize}
+  \itemsep-.2em
+  \item Maintained Singularity, HubSpot's open-source Mesos scheduler
+  framework
+  \item Ported Baragon, HubSpot's open-source load-balancer management
+  tooling, from AWS' Classic Load Balancers to the new Application
+  Load Balancers to take advantage of the new DDOS-prevention infrastructure
+  \item Built internal work-queue system for deferred data processing
+  backed by Amazon SQS and MySQL, to improve the horizontal scalability of
+  an older system backed by HBase
+\end{itemize}
+
+
+\hsub{NantHealth LLC} \hfill Jan. 2016 - Aug. 2016 \\
+Product Research Co-Op
+\begin{itemize}
+    \itemsep-.2em
+    \item Built a full-stack Javascript application with Polymer and Express
+    as a tech demo for interoperability with EHR sources using FHIR and for
+    for document exchange between health insurance companies
+    and health care providers, and was added to the roadmap for
+    the NaviNet product.
+    \item Built ETL infrastructure using Apache Spark to transform between
+    storage formats and remove PII. One usecase was  allowing
+    developers at NantHealth to generate test data that was not
+    HIPAA protected from production data in our data lake.
+\end{itemize}
+
+\hsub{Northeastern University} \hfill Sept. 2015 - Dec. 2015 \\
+Peer Tutor
+\begin{itemize}
+    \itemsep-.2em
+    \item Administered labs and provided office hours for Fundamentals of
+    Computer Science I
+    \item Graded homeworks and monitored student progress
+\end{itemize}
+
+
+\hmain{Interests}
+Semi-competitive running
+
+
+\begin{center}
+\hsub{References available upon request}
+\end{center}
+
+
+\end{document}

--- a/resume/resume.ltx
+++ b/resume/resume.ltx
@@ -23,32 +23,31 @@
 \hname{Peter Teixeira} \\
 teixeira.p@husky.neu.edu \S{} (774) 641-4648 \\
 linkedin.com/in/PtrTeixeira \S{} github.com/PtrTeixeira \\
-Available: January - July 2018
 \end{center}
 
-\hsub{Local Address:} \hfill \hsub{Permanent Address:} \\
-50 Leon Street        \hfill 30 Oakridge Road \\
-Box 3166              \hfill Holden, MA 01520 \\
+\hsub{Address:} \\
+24 Westland Ave \\
+\#BAS \\
 Boston, MA 02115
 
 
 \hmain{Education}
-\hsub{Northeastern University}, Boston, MA \hfill 2014 - Present \\
-\emph{College of Computer and Information Science} \\
-Candidate for a Bachelor of Science in Computer Science and Mathematics, 2019 \\
-\textbf{GPA: 3.90/4.00}
+\hsub{Northeastern University}, Boston, MA \hfill 2014 - 2019 \\
+\emph{Khoury College of Computer Sciences} \\
+Bachelor of Science in Computer Science and Mathematics, 2019 \\
+\emph{summa cum laude (GPA: 3.93/4.00)}
 
 \begin{tabular}{p{5cm}p{12cm}}
 Related Coursework: &
-        Statistics and Stochastic Processes, Object-Oriented Design,
+        Statistics and Stochastic Processes, Compiler Design,
         Software Development\\
-Activities: & Habitat for Humanity, Club Running
+Activities: & Club Running
 \end{tabular}
 
 \hmain{Computer Knowledge}
 \begin{tabular}{p{5cm}p{12cm}}
 Languages: & Java, Javascript,  Kotlin \\
-Technologies: & React, Redux, JDBI \\
+Technologies: & React, JDBI, Ansible, Terraform \\
 \end{tabular}
 
 
@@ -61,7 +60,7 @@ implemented in Racket
 \end{tabular}
 
 \hmain{Work Experience}
-\hsub{HubSpot} \hfill Jan. 2017 - July 2017 \\
+\hsub{HubSpot} \hfill June 2019 - Present \\
 Product Co-Op
 \begin{itemize}
   \itemsep-.2em
@@ -102,7 +101,7 @@ Peer Tutor
 
 
 \hmain{Interests}
-Semi-competitive running
+Semi-competitive running (15:59 5k, 2:44 marathon)
 
 
 \begin{center}


### PR DESCRIPTION
Why? Same reason that I'm building everything else in Bazel, to keep as much as possible in one place. This isn't terribly interesting. I found a nice set of rules that let me use Bazel to build LaTeX documents, which is how I was keeping my resume anyways. 

I have a vague recollection of a set of a set of Bazel PanDoc rules, which might be a nice transition. I could write my resume in Markdown then compile it to HTML and host it on GitHub pages or compile it to a PDF and give people a physical copy.

But at the moment, this is basically a direct port of my resume from the last time that I needed to use it, plus some small updates that I'll need to patch up later.