### PR TITLE
Save test results

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,6 +11,11 @@ jobs:
       - run: cp .circleci/bazel.rc /etc/bazel.bazelrc
       - run: bazel build //...
       - run: bazel test //...
+      - run: |
+          mkdir tmp
+          find -L bazel-testlogs -name 'test.xml' -printf '%h\n' | xargs -n1 -I{} cp -r {} tmp
+      - store_test_results:
+          path: tmp
       - save_cache:
           key: "v1-bazel-cache"
           paths:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,10 +12,14 @@ jobs:
       - run: bazel build //...
       - run: bazel test //...
       - run: |
-          mkdir tmp
-          find -L bazel-testlogs -name 'test.xml' -printf '%h\n' | xargs -n1 -I{} cp -r {} tmp
+          mkdir tests
+          find -L bazel-testlogs -name 'test.xml' -printf '%h\n' | xargs -n1 -I{} cp -r {} tests
+          mkdir artifacts
+          cp bazel-bin/punchcard/punchcard.deb artifacts
       - store_test_results:
-          path: tmp
+          path: tests
+      - store_artifacts:
+          path: artifacts/punchcard.deb
       - save_cache:
           key: "v1-bazel-cache"
           paths:


### PR DESCRIPTION
Save test results & build artifacts (ie, a deb file) from the builds. Saving test files is a nice convenience for checking on a build status in the UI (although it doesn't actually give that much information), and building the deb lets me have (kind-of) canonical builds for what I'm going to be deploying. So that's nice.