### PR TITLE
Clean up mvb

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,9 @@ I don't know Bazel that well, but I'm learning as I go.
 * `kotlin-dropwizard-dsl` - A small Kotlin library for configuring Dropwizard
   * Build with `bazel build //kotlin-dropwizard-dsl/...`
   * Test with `bazel test //kotlin-dropwizard-dsl/...`
+* `mvb` - A command-line batch file renamer
+  * Build with `bazel build //mvb/...`
+  * Test with `bazel test //mvb/...`
 * third-party has external dependency things in it.
 
 You can test everything (in CI, for instance) with `bazel test ...`.

--- a/mvb/BUILD
+++ b/mvb/BUILD
@@ -1,5 +1,3 @@
-package(default_visibility = ["//visibility:public"])
-
 load("@io_bazel_rules_rust//rust:rust.bzl", "rust_binary", "rust_library", "rust_test")
 
 rust_library(

--- a/mvb/BUILD
+++ b/mvb/BUILD
@@ -2,14 +2,31 @@ package(default_visibility = ["//visibility:public"])
 
 load("@io_bazel_rules_rust//rust:rust.bzl", "rust_binary", "rust_library", "rust_test")
 
+rust_library(
+    name = "lib",
+    srcs = [
+        "src/cli.rs",
+        "src/lib.rs",
+    ],
+    deps = [
+        "//third-party/cargo:clap",
+        "//third-party/cargo:regex",
+    ],
+)
+
 rust_binary(
     name = "mvb",
     srcs = [
         "src/main.rs",
     ],
     deps = [
-        "//third-party/cargo:clap",
+        ":lib",
         "//third-party/cargo:regex",
         "//third-party/cargo:walkdir",
     ],
+)
+
+rust_test(
+    name = "mvb_test",
+    crate = ":lib",
 )

--- a/mvb/README.md
+++ b/mvb/README.md
@@ -24,4 +24,4 @@ have all of the interesting files backed up anyway.
 
 ## Development
 
-Build with `bazel build ...`. Test with (there's no tests) `bazel test ...`.
+Build with `bazel build ...`. Test with `bazel test ...`.

--- a/mvb/README.md
+++ b/mvb/README.md
@@ -1,0 +1,27 @@
+mvb CLI Utility
+==============
+
+A batch file-moving utility. 
+
+## Should I Use this? 
+
+No.
+
+## Usage
+
+Usage example:
+
+```
+mvb '(.+)\.json' '$1.yml'
+```
+
+Currently, it's basically just delegating to the Rust's regex engine, which is
+why the grammer is rather unfortunate. It also unbelieveably primitive. I make
+no guarantees as to what will happen if you try to move 0 files, or move files
+into a directory that isn't present, or any other reasonable edge cases. In
+short, you shouldn't use this unless you know exactly what you're doing, and you
+have all of the interesting files backed up anyway.
+
+## Development
+
+Build with `bazel build ...`. Test with (there's no tests) `bazel test ...`.

--- a/mvb/src/cli.rs
+++ b/mvb/src/cli.rs
@@ -1,0 +1,86 @@
+use clap::{App, Arg, Result as ClapResult};
+use std::ffi::OsString;
+
+pub struct CommandLine {
+    pub from_pattern: String,
+    pub to_pattern: String,
+    pub preserve: bool,
+}
+
+pub fn parse_command_line<I, T>(args: I) -> ClapResult<CommandLine>
+where
+    I: IntoIterator<Item = T>,
+    T: Into<OsString> + Clone,
+{
+    let matches = App::new("mvb")
+        .author("Peter Teixeira")
+        .about("Bulk renames files")
+        .arg(Arg::with_name("from_pattern").required(true).index(1))
+        .arg(Arg::with_name("to_pattern").required(true).index(2))
+        .arg(
+            Arg::with_name("preserve")
+                .required(false)
+                .short("p")
+                .long("preserve")
+                .help("Preserve original files (make copies at new location)"),
+        )
+        .get_matches_from_safe(args)?;
+
+    let from_pattern = matches.value_of("from_pattern").unwrap();
+    let to_pattern = matches.value_of("to_pattern").unwrap();
+    let preserve = matches.is_present("preserve");
+
+    return Ok(CommandLine {
+        from_pattern: from_pattern.to_owned(),
+        to_pattern: to_pattern.to_owned(),
+        preserve: preserve,
+    });
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    pub fn parse_command_line_returns_err_on_help_flag() {
+        if let Ok(_) = parse_command_line(&["mvb", "--help"]) {
+            assert!(false, "Should have errored out on help flag")
+        }
+    }
+
+    #[test]
+    pub fn parse_command_line_returns_err_on_version_flag() {
+        if let Ok(_) = parse_command_line(&["mvb", "--version"]) {
+            assert!(false, "Should have errored out on version flag")
+        }
+    }
+
+    #[test]
+    pub fn parse_command_line_returns_err_on_help_flag_even_if_other_args_passed() {
+        if let Ok(_) = parse_command_line(&["mvb", "--help", "name1", "name2"]) {
+            assert!(false, "Should have errored out on version flag")
+        }
+    }
+
+    #[test]
+    pub fn parse_command_line_sets_preserve_flag_if_present() {
+        let command_line = parse_command_line(&["mvb", "-p", "name1", "name2"]).unwrap();
+
+        assert!(command_line.preserve, "Preserve flag should be set");
+    }
+
+    #[test]
+    pub fn perserve_flag_defaults_to_false() {
+        let command_line = parse_command_line(&["mvb", "name1", "name2"]).unwrap();
+
+        assert!(!command_line.preserve, "Preserve flag should be false");
+    }
+
+    #[test]
+    pub fn parse_command_line_sets_from_and_to_patterns() {
+        let command_line = parse_command_line(&["mvb", "name1", "name2"]).unwrap();
+
+        assert_eq!(command_line.from_pattern, "name1");
+        assert_eq!(command_line.to_pattern, "name2");
+    }
+}

--- a/mvb/src/lib.rs
+++ b/mvb/src/lib.rs
@@ -1,0 +1,46 @@
+extern crate clap;
+extern crate regex;
+
+pub mod cli;
+
+use regex::Regex;
+use std::borrow::Borrow;
+use std::path::Path;
+use std::path::PathBuf;
+
+pub fn get_new_path(filename: &str, target_pattern: &str, from_pattern: &Regex) -> Option<PathBuf> {
+    if !from_pattern.is_match(filename) {
+        return None;
+    }
+
+    let replaced_name = from_pattern.replace(filename, target_pattern);
+    let target_file_name: &str = replaced_name.borrow();
+    let target_file_path = Path::new(target_file_name);
+    return Some(target_file_path.to_owned());
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use regex::Regex;
+
+    #[test]
+    fn it_returns_none_if_filename_doesnt_match_from_pattern() {
+        let filename = "/app/file1.txt";
+        let from_pattern = Regex::new("file2.txt").unwrap();
+        let to_pattern = "$0.bkp";
+
+        let result = get_new_path(filename, to_pattern, &from_pattern);
+        assert_eq!(result, None);
+    }
+
+    #[test]
+    fn it_returns_some_of_path_if_replacement_made() {
+        let filename = "/app/file1.txt";
+        let from_pattern = Regex::new("file1.txt").unwrap();
+        let to_pattern = "$0.bkp";
+
+        let result = get_new_path(filename, to_pattern, &from_pattern);
+        assert_eq!(result, Some(PathBuf::from(r"/app/file1.txt.bkp")));
+    }
+}

--- a/mvb/src/main.rs
+++ b/mvb/src/main.rs
@@ -33,7 +33,13 @@ fn run_app() -> bool {
         preserve,
     } = command_line;
 
-    let re = Regex::new(&from_pattern).expect("Could not parse input pattern");
+    let re = match Regex::new(&from_pattern) {
+        Ok(re) => re,
+        Err(_) => {
+            eprintln!("Could not parse '{}' as a regular expression", from_pattern);
+            return false;
+        }
+    };
 
     let mut exit_ok = true;
     for entry in WalkDir::new(".").into_iter().filter_map(|e| e.ok()) {

--- a/mvb/src/main.rs
+++ b/mvb/src/main.rs
@@ -1,13 +1,13 @@
-extern crate clap;
+extern crate lib;
 extern crate regex;
 extern crate walkdir;
 
-use clap::{App, Arg};
+use lib::cli::{parse_command_line, CommandLine};
+use lib::get_new_path;
 use regex::Regex;
-use std::borrow::Borrow;
+use std::env;
 use std::fs;
 use std::io;
-use std::path::Path;
 use walkdir::{DirEntry, WalkDir};
 
 fn main() {
@@ -19,28 +19,25 @@ fn main() {
 }
 
 fn run_app() -> bool {
-    let matches = App::new("mvb")
-        .author("Peter Teixeira")
-        .about("Bulk renames files")
-        .arg(Arg::with_name("from_pattern").required(true).index(1))
-        .arg(Arg::with_name("to_pattern").required(true).index(2))
-        .arg(
-            Arg::with_name("preserve")
-                .required(false)
-                .short("p")
-                .long("preserve")
-                .help("Preserve original files (make copies at new location)"),
-        )
-        .get_matches();
+    let command_line = match parse_command_line(env::args_os()) {
+        Ok(cl) => cl,
+        Err(e) => {
+            eprintln!("{}", e);
+            return true;
+        }
+    };
 
-    let from_pattern = matches.value_of("from_pattern").unwrap();
-    let to_pattern = matches.value_of("to_pattern").unwrap();
-    let backup = matches.is_present("preserve");
-    let re = Regex::new(from_pattern).expect("Could not parse input pattern");
+    let CommandLine {
+        from_pattern,
+        to_pattern,
+        preserve,
+    } = command_line;
+
+    let re = Regex::new(&from_pattern).expect("Could not parse input pattern");
 
     let mut exit_ok = true;
     for entry in WalkDir::new(".").into_iter().filter_map(|e| e.ok()) {
-        let move_result = if backup {
+        let move_result = if preserve {
             try_copy_file(entry, &to_pattern, &re)
         } else {
             try_move_file(entry, &to_pattern, &re)
@@ -57,28 +54,14 @@ fn run_app() -> bool {
 
 fn try_move_file(entry: DirEntry, target_pattern: &str, re: &Regex) -> Option<io::Result<()>> {
     let filename = entry.file_name().to_str()?;
-
-    if !re.is_match(filename) {
-        return None;
-    }
-
-    let replaced_name = re.replace(filename, target_pattern);
-    let target_file_name: &str = replaced_name.borrow();
-    let target_file_path = Path::new(target_file_name);
+    let target_file_path = get_new_path(filename, target_pattern, re)?;
 
     Some(fs::rename(entry.path(), target_file_path))
 }
 
 fn try_copy_file(entry: DirEntry, target_pattern: &str, re: &Regex) -> Option<io::Result<()>> {
     let filename = entry.file_name().to_str()?;
-
-    if !re.is_match(filename) {
-        return None;
-    }
-
-    let replaced_name = re.replace(filename, target_pattern);
-    let target_file_name: &str = replaced_name.borrow();
-    let target_file_path = Path::new(target_file_name);
+    let target_file_path = get_new_path(filename, target_pattern, re)?;
 
     return match fs::copy(entry.path(), target_file_path) {
         Ok(_) => Some(Ok(())),

--- a/mvb/src/main.rs
+++ b/mvb/src/main.rs
@@ -2,46 +2,70 @@ extern crate clap;
 extern crate regex;
 extern crate walkdir;
 
-use clap::{Arg, App};
+use clap::{App, Arg};
 use regex::Regex;
-use std::fs;
 use std::borrow::Borrow;
+use std::fs;
+use std::io;
 use std::path::Path;
-use walkdir::{ DirEntry, WalkDir };
+use walkdir::{DirEntry, WalkDir};
 
 fn main() {
-  let matches = App::new("mvb")
-      .version("0.1.0")
-      .author("Peter Teixeira")
-      .about("Bulk renames files")
-      .arg(Arg::with_name("from_pattern").required(true).index(1))
-      .arg(Arg::with_name("to_pattern").required(true).index(2))
-      .get_matches();
+    let matches = App::new("mvb")
+        .author("Peter Teixeira")
+        .about("Bulk renames files")
+        .arg(Arg::with_name("from_pattern").required(true).index(1))
+        .arg(Arg::with_name("to_pattern").required(true).index(2))
+        .arg(
+            Arg::with_name("preserve")
+                .required(false)
+                .short("p")
+                .long("preserve")
+                .help("Preserve original files (make copies at new location)"),
+        )
+        .get_matches();
 
-  let from_pattern = matches.value_of("from_pattern").unwrap();
-  let to_pattern = matches.value_of("to_pattern").unwrap();
-  let re = Regex::new(from_pattern)
-      .expect("Could not parse input pattern");
+    let from_pattern = matches.value_of("from_pattern").unwrap();
+    let to_pattern = matches.value_of("to_pattern").unwrap();
+    let backup = matches.is_present("preserve");
+    let re = Regex::new(from_pattern).expect("Could not parse input pattern");
 
-  for entry in WalkDir::new(".").into_iter().filter_map(|e| e.ok()) {
-      try_move_file(entry, &to_pattern, &re);
-  }
+    for entry in WalkDir::new(".").into_iter().filter_map(|e| e.ok()) {
+        if backup {
+            try_copy_file(entry, &to_pattern, &re);
+        } else {
+            try_move_file(entry, &to_pattern, &re);
+        }
+    }
 }
 
-fn try_move_file(entry: DirEntry, target_pattern: &str, re: &Regex) -> Option<()> {
-  let filename = entry.file_name().to_str()?;
-  
-  if !re.is_match(filename) {
-      return None;
-  }
+fn try_move_file(entry: DirEntry, target_pattern: &str, re: &Regex) -> Option<io::Result<()>> {
+    let filename = entry.file_name().to_str()?;
 
-  let replaced_name = re.replace(filename, target_pattern);
-  let target_file_name: &str = replaced_name.borrow();
-  let target_file_path = Path::new(target_file_name);
+    if !re.is_match(filename) {
+        return None;
+    }
 
-  println!("Renaming {} to {:?}", entry.path().display(), target_file_name);
-  return match fs::rename(entry.path(), target_file_path) {
-      Ok(_) => None,
-      Err(e) => panic!(e),
-  }
+    let replaced_name = re.replace(filename, target_pattern);
+    let target_file_name: &str = replaced_name.borrow();
+    let target_file_path = Path::new(target_file_name);
+
+    Some(fs::rename(entry.path(), target_file_path))
+}
+
+fn try_copy_file(entry: DirEntry, target_pattern: &str, re: &Regex) -> Option<io::Result<()>> {
+    let filename = entry.file_name().to_str()?;
+
+    if !re.is_match(filename) {
+        return None;
+    }
+
+    let replaced_name = re.replace(filename, target_pattern);
+    let target_file_name: &str = replaced_name.borrow();
+    let target_file_path = Path::new(target_file_name);
+
+    return match fs::copy(entry.path(), target_file_path) {
+        Ok(_) => Some(Ok(())),
+        Err(e) => Some(Err(e))
+    }
 }


### PR DESCRIPTION
Clean up the bulk move CLI utility. 

I don't need to do things like this often, but every time I do I want a better tool to do it. Arcane invocations of `find -exec` are not really my jam.

This tool is, as its README suggests, garbage. But I can make it better over time.