### PR TITLE
Punchcard: Add correct scopes for OAuth

### DIFF
--- a/punchcard/server/src/main/kotlin/com/ptrteixeira/punchcard/resources/MetricsResource.kt
+++ b/punchcard/server/src/main/kotlin/com/ptrteixeira/punchcard/resources/MetricsResource.kt
@@ -3,8 +3,11 @@ package com.github.ptrteixeira.punchcard.resources
 import com.codahale.metrics.MetricRegistry
 import javax.ws.rs.GET
 import javax.ws.rs.Path
+import javax.ws.rs.Produces
+import javax.ws.rs.core.MediaType
 
 @Path("/metrics")
+@Produces(MediaType.APPLICATION_JSON)
 internal class MetricsResource(private val registry: MetricRegistry) {
 
     @GET


### PR DESCRIPTION
I was never setting the scopes on the OAuth redirect to Strava, which
Strava now(ish) requires. I'm not using forever tokens, so I'm fine on
that front (though I'm also actually not using refresh tokens either
:shrug:).

Also includes a small bugfix that attaches the content-type to the
metrics endpoint, which wasn't the case previously (and was causing a
500 if I didn't do set the Accept on the request).