### PR TITLE
Some general CI changes

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -25,10 +25,6 @@ jobs:
           root: artifacts
           paths:
             - "*.deb"
-      - store_artifacts:
-          path: artifacts/punchcard.deb
-      - store_artifacts:
-          path: artifacts/gopunchcard.deb
       - save_cache:
           key: v1-bazel-cache-{{ checksum "WORKSPACE" }}
           paths:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,11 +3,13 @@ jobs:
   build_primary:
     working_directory: ~/cookbook
     docker:
-      - image: l.gcr.io/google/bazel:0.29.0
+      - image: l.gcr.io/google/bazel:0.29.1
     steps:
       - checkout
       - restore_cache:
-          key: "v1-bazel-cache"
+          keys:
+            - v1-bazel-cache-{{ checksum "WORKSPACE" }}
+            - v1-bazel-cache
       - run: cp .circleci/bazel.rc /etc/bazel.bazelrc
       - run: echo "1.0.$CIRCLE_BUILD_NUM" | tee version_file
       - run: bazel build //...
@@ -19,12 +21,15 @@ jobs:
           find -L bazel-bin -name '*.deb' -print -exec cp {} artifacts \;
       - store_test_results:
           path: tests
+      - persist_to_workspace:
+          paths:
+            - "artifacts/*.deb"
       - store_artifacts:
           path: artifacts/punchcard.deb
       - store_artifacts:
           path: artifacts/gopunchcard.deb
       - save_cache:
-          key: "v1-bazel-cache"
+          key: v1-bazel-cache-{{ checksum "WORKSPACE" }}
           paths:
             - "/home/circleci/.cache/bazel"
   build_ui:
@@ -35,6 +40,16 @@ jobs:
       - run: yarn
       - run: yarn workspaces run build
       - run: yarn workspaces run test
+  deploy:
+    docker:
+      - image: circleci/openjdk:8u181-jdk-node-browsers
+    steps:
+      - attach_workspace:
+          at: /tmp/workspace
+      - store_artifacts:
+          path: /tmp/workspace/artifacts/punchcard.deb
+      - store_artifacts:
+          path: /tmp/workspace/artifacts/gopunchcard.deb
 
 workflows:
   version: 2
@@ -42,3 +57,8 @@ workflows:
     jobs:
     - build_primary
     - build_ui
+    - deploy:
+        requires: [build_primary]
+        filters:
+          branches:
+            only: master

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,8 +22,9 @@ jobs:
       - store_test_results:
           path: tests
       - persist_to_workspace:
+          root: artifacts
           paths:
-            - "artifacts/*.deb"
+            - "*.deb"
       - store_artifacts:
           path: artifacts/punchcard.deb
       - store_artifacts:
@@ -47,9 +48,9 @@ jobs:
       - attach_workspace:
           at: /tmp/workspace
       - store_artifacts:
-          path: /tmp/workspace/artifacts/punchcard.deb
+          path: /tmp/workspace/punchcard.deb
       - store_artifacts:
-          path: /tmp/workspace/artifacts/gopunchcard.deb
+          path: /tmp/workspace/gopunchcard.deb
 
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,18 +9,20 @@ jobs:
       - restore_cache:
           key: "v1-bazel-cache"
       - run: cp .circleci/bazel.rc /etc/bazel.bazelrc
-      - run: echo "1.0.$CIRCLE_BUILD_NUM" > version_file
+      - run: echo "1.0.$CIRCLE_BUILD_NUM" | tee version_file
       - run: bazel build //...
       - run: bazel test //...
       - run: |
           mkdir tests
           find -L bazel-testlogs -name 'test.xml' -printf '%h\n' | xargs -n1 -I{} cp -r {} tests
           mkdir artifacts
-          find -L bazel-bin -name '*.deb' -exec cp {} artifacts \;
+          find -L bazel-bin -name '*.deb' -print -exec cp {} artifacts \;
       - store_test_results:
           path: tests
       - store_artifacts:
           path: artifacts/punchcard.deb
+      - store_artifacts:
+          path: artifacts/gopunchcard.deb
       - save_cache:
           key: "v1-bazel-cache"
           paths:


### PR DESCRIPTION
Probably too big in scope for a single PR, but that be how it is sometimes.

* Bump from bazel 0.29.0 -> 0.29.1
* Only save build artifacts for master builds
* Small increase in logging verbosity to help me track down other issues
* More precise caching to (hopefully) speed up builds