### PR TITLE
Write my own Go assertions library

### DIFF
--- a/go-assert/BUILD.bazel
+++ b/go-assert/BUILD.bazel
@@ -1,0 +1,15 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["assert.go"],
+    importpath = "github.com/PtrTeixeira/cookbook/go-assert",
+    visibility = ["//visibility:public"],
+)
+
+go_test(
+    name = "go_default_test",
+    srcs = ["assert_test.go"],
+    embed = [":go_default_library"],
+    size = "small",
+)

--- a/go-assert/BUILD.bazel
+++ b/go-assert/BUILD.bazel
@@ -9,7 +9,7 @@ go_library(
 
 go_test(
     name = "go_default_test",
+    size = "small",
     srcs = ["assert_test.go"],
     embed = [":go_default_library"],
-    size = "small",
 )

--- a/go-assert/assert.go
+++ b/go-assert/assert.go
@@ -1,22 +1,47 @@
 package assert
 
 import (
+	"fmt"
 	"testing"
 )
 
 type BooleanAssertion func(val bool) (bool, string)
+type IntegerAssertion func(val int) (bool, string)
 
 func IsTrue() BooleanAssertion {
-	return func(val bool) (bool, string) {
-    if !val {
-      return false, "Expected true but was: \"false\""
-    }
-    return val, ""
-  }
+	return IsEqualToBool(true)
 }
 
-func AssertThat(t *testing.T, val bool, test BooleanAssertion) {
-  if result, msg := test(val); !result {
-    t.Error(msg)
-  }
+func IsFalse() BooleanAssertion {
+	return IsEqualToBool(false)
+}
+
+func IsEqualToBool(cond bool) BooleanAssertion {
+	return func(val bool) (bool, string) {
+		if val != cond {
+			return false, fmt.Sprintf("Expected \"%v\" but was: \"%v\"", cond, val)
+		}
+		return true, ""
+	}
+}
+
+func IsEqualToInt(cond int) IntegerAssertion {
+	return func(val int) (bool, string) {
+		if val != cond {
+			return false, fmt.Sprintf("Expected \"%v\" but was: \"%v\"", cond, val)
+		}
+		return true, ""
+	}
+}
+
+func AssertThatBool(t *testing.T, val bool, test BooleanAssertion) {
+	if result, msg := test(val); !result {
+		t.Error(msg)
+	}
+}
+
+func AssertThatInt(t *testing.T, val int, test IntegerAssertion) {
+	if result, msg := test(val); !result {
+		t.Error(msg)
+	}
 }

--- a/go-assert/assert.go
+++ b/go-assert/assert.go
@@ -1,0 +1,22 @@
+package assert
+
+import (
+	"testing"
+)
+
+type BooleanAssertion func(val bool) (bool, string)
+
+func IsTrue() BooleanAssertion {
+	return func(val bool) (bool, string) {
+    if !val {
+      return false, "Expected true but was: \"false\""
+    }
+    return val, ""
+  }
+}
+
+func AssertThat(t *testing.T, val bool, test BooleanAssertion) {
+  if result, msg := test(val); !result {
+    t.Error(msg)
+  }
+}

--- a/go-assert/assert_test.go
+++ b/go-assert/assert_test.go
@@ -5,33 +5,33 @@ import (
 )
 
 func TestBooleanAssertion(t *testing.T) {
-  t.Run("IsTrue matches true", func(t *testing.T) {
-    matcher := IsTrue()
-    result, _ := matcher(true)
+	t.Run("IsTrue matches true", func(t *testing.T) {
+		matcher := IsTrue()
+		result, _ := matcher(true)
 
-    if !result {
-      t.Errorf("Should have matched true!")
-    }
-  })
+		if !result {
+			t.Errorf("Should have matched true!")
+		}
+	})
 
-  t.Run("IsTrue does not match false", func(t *testing.T) {
-    matcher := IsTrue()
-    result, msg := matcher(false)
+	t.Run("IsTrue does not match false", func(t *testing.T) {
+		matcher := IsTrue()
+		result, msg := matcher(false)
 
-    if result {
-      t.Errorf("Should not have matched false!")
-    }
-    if msg != "Expected true but was: \"false\"" {
-      t.Errorf("Got incorrect message: %q", msg)
-    }
-  })
+		if result {
+			t.Errorf("Should not have matched false!")
+		}
+		if msg != "Expected \"true\" but was: \"false\"" {
+			t.Errorf("Got incorrect message: %q", msg)
+		}
+	})
 }
 
-// TODO(pteixeira) Need to modify how the stackframe unwinds 
-// to get the error message to come from lines like this, 
+// TODO(pteixeira) Need to modify how the stackframe unwinds
+// to get the error message to come from lines like this,
 // rather than from a line in this library
 func TestAssertThat(t *testing.T) {
-  t.Run("AssertThat does nothing when matched", func(t *testing.T) {
-    AssertThat(t, true, IsTrue())
-  })
+	t.Run("AssertThat does nothing when matched", func(t *testing.T) {
+		AssertThatBool(t, true, IsTrue())
+	})
 }

--- a/go-assert/assert_test.go
+++ b/go-assert/assert_test.go
@@ -1,0 +1,37 @@
+package assert
+
+import (
+	"testing"
+)
+
+func TestBooleanAssertion(t *testing.T) {
+  t.Run("IsTrue matches true", func(t *testing.T) {
+    matcher := IsTrue()
+    result, _ := matcher(true)
+
+    if !result {
+      t.Errorf("Should have matched true!")
+    }
+  })
+
+  t.Run("IsTrue does not match false", func(t *testing.T) {
+    matcher := IsTrue()
+    result, msg := matcher(false)
+
+    if result {
+      t.Errorf("Should not have matched false!")
+    }
+    if msg != "Expected true but was: \"false\"" {
+      t.Errorf("Got incorrect message: %q", msg)
+    }
+  })
+}
+
+// TODO(pteixeira) Need to modify how the stackframe unwinds 
+// to get the error message to come from lines like this, 
+// rather than from a line in this library
+func TestAssertThat(t *testing.T) {
+  t.Run("AssertThat does nothing when matched", func(t *testing.T) {
+    AssertThat(t, true, IsTrue())
+  })
+}

--- a/go-assert/go.mod
+++ b/go-assert/go.mod
@@ -1,0 +1,3 @@
+module github.com/PtrTeixeira/cookbook/go-assert
+
+go 1.13

--- a/punchcard/go-server/BUILD.bazel
+++ b/punchcard/go-server/BUILD.bazel
@@ -31,4 +31,7 @@ go_test(
     size = "small",
     srcs = ["stats_test.go"],
     embed = [":go_default_library"],
+    deps = [
+        "//go-assert:go_default_library",
+    ],
 )

--- a/punchcard/go-server/stats_test.go
+++ b/punchcard/go-server/stats_test.go
@@ -2,22 +2,21 @@ package main
 
 import (
 	"testing"
+
+	. "github.com/PtrTeixeira/cookbook/go-assert"
 )
 
 func TestAddToMap(t *testing.T) {
 	t.Run("it sets the value to 1 if the value was absent", func(t *testing.T) {
 		dest := make(map[int]int)
 		increment(4, dest)
-		if dest[4] != 1 {
-			t.Errorf("Expected value 1, was %v", dest[4])
-		}
+		AssertThatInt(t, dest[4], IsEqualToInt(1))
 	})
+
 	t.Run("it increments the value in the map if it is present", func(t *testing.T) {
 		dest := make(map[int]int)
 		dest[4] = 2
 		increment(4, dest)
-		if dest[4] != 3 {
-			t.Errorf("Expected value 3, was %v", dest[4])
-		}
+		AssertThatInt(t, dest[4], IsEqualToInt(3))
 	})
 }


### PR DESCRIPTION
I kinda like the way it looks, ngl (kind of based on Hamcrest). 

It'd probably be a better solution to use an already-written assertions / testing 
library - indeed, I have been using stretchr/testify - but unfortunately using 
Bazel makes external deps frustrating at best. So I decided to write my own assertions 
library, which is something I've wanted to do (albeit in Java or Racket) for ages anyway.

This one as some problems; among other things, I'm going to need to figure out how 
to get the stack trace / error location to indicate the test error in the calling code, rather 
than in the assertion library. Also, I didn't entirely realize when I started this that (1) Go 
doesn't have generics, and (2) Go isn't a fan of overloading. Both of those make the interface
rather ugly at the moment. But it's good enough for right now, and that works for me.