### PR TITLE
Actually fix workspace path

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -52,9 +52,9 @@ jobs:
           at: /tmp/workspace
       - store_artifacts:
           path: /tmp/workspace/gopunchcard.deb
-      - run: tar -cvzf punchcard-ui.tgz packages/punchcard-ui/build
+      - run: tar -cvzf punchcard-ui.tgz /tmp/workspace/packages/punchcard-ui/build
       - store_artifacts:
-          path: /tmp/workspace/punchcard-ui.tgz
+          path: punchcard-ui.tgz
 
 workflows:
   version: 2


### PR DESCRIPTION
Damn, I'm a moron. In any case, the good news is that using the
`--disk_cache` flag correctly in Bazel made the build go from ~4 minutes
to ~1 minute, which is frankly pretty mind blowing (and a decent amount
of that is actually pulling the Bazel image).